### PR TITLE
Increase max heap

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -149,6 +149,6 @@ lazy val commonSettings = Seq(
     setupDirectories(name.value),
     Cmd("COPY", s"2/opt/docker/lib/${(assembly / assemblyJarName).value}", s"/opt/${(assembly / assemblyJarName).value}"),
     Cmd("USER", "1002"),
-    ExecCmd("CMD", "java", "-jar", s"/opt/${(assembly / assemblyJarName).value}")
+    ExecCmd("CMD", "java", "-Xmx2g", "-jar", s"/opt/${(assembly / assemblyJarName).value}")
   )
 )


### PR DESCRIPTION
There is an IO in preservica with 1200 assets which has 1800ish versions
and a 45Mb inventory file.

The OCFL library reads the whole thing into memory and it's running out
of heap space.

I have no idea what to set it to but this should cover us for a while.
