### PR TITLE
DR2-1843 Stop using Option for SO

### DIFF
--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Message.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Message.scala
@@ -8,10 +8,10 @@ import uk.gov.nationalarchives.custodialcopy.Processor.ObjectType
 object Message {
   sealed trait ReceivedSnsMessage {
     val ref: UUID
-    val messageText: String
   }
-  case class IoReceivedSnsMessage(ref: UUID, messageText: String) extends ReceivedSnsMessage
-  case class CoReceivedSnsMessage(ref: UUID, messageText: String) extends ReceivedSnsMessage
+  case class IoReceivedSnsMessage(ref: UUID) extends ReceivedSnsMessage
+  case class CoReceivedSnsMessage(ref: UUID) extends ReceivedSnsMessage
+  case class SoReceivedSnsMessage(ref: UUID) extends ReceivedSnsMessage
 
   case class SendSnsMessage(entityType: EntityType, ioRef: UUID, objectType: ObjectType, status: ObjectStatus, tableItemIdentifier: String | UUID)
 }

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/ProcessorTest.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/ProcessorTest.scala
@@ -270,9 +270,9 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
         )
       )
 
-    val response: MessageResponse[Option[ReceivedSnsMessage]] = MessageResponse[Option[ReceivedSnsMessage]](
+    val response: MessageResponse[ReceivedSnsMessage] = MessageResponse[ReceivedSnsMessage](
       "receiptHandle2",
-      Option(IoReceivedSnsMessage(changedFileId, s"io:$changedFileId"))
+      IoReceivedSnsMessage(changedFileId)
     )
 
     utils.processor.process(response).unsafeRunSync()
@@ -323,10 +323,10 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
         )
       )
 
-    val response: MessageResponse[Option[ReceivedSnsMessage]] =
-      MessageResponse[Option[ReceivedSnsMessage]](
+    val response: MessageResponse[ReceivedSnsMessage] =
+      MessageResponse[ReceivedSnsMessage](
         "receiptHandle1",
-        Option(IoReceivedSnsMessage(missingFileId, s"io:$missingFileId"))
+        IoReceivedSnsMessage(missingFileId)
       )
     utils.processor.process(response).unsafeRunSync()
 

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/testUtils/ExternalServicesTestUtils.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/testUtils/ExternalServicesTestUtils.scala
@@ -24,7 +24,7 @@ import uk.gov.nationalarchives.DASQSClient.MessageResponse
 import uk.gov.nationalarchives.custodialcopy.CustodialCopyObject.MetadataObject
 import uk.gov.nationalarchives.custodialcopy.{CustodialCopyObject, Message, OcflService, Processor}
 import uk.gov.nationalarchives.custodialcopy.Main.{Config, IdWithSourceAndDestPaths}
-import uk.gov.nationalarchives.custodialcopy.Message.{CoReceivedSnsMessage, IoReceivedSnsMessage, ReceivedSnsMessage, SendSnsMessage}
+import uk.gov.nationalarchives.custodialcopy.Message.{CoReceivedSnsMessage, IoReceivedSnsMessage, ReceivedSnsMessage, SendSnsMessage, SoReceivedSnsMessage}
 import uk.gov.nationalarchives.custodialcopy.OcflService.MissingAndChangedObjects
 import uk.gov.nationalarchives.custodialcopy.OcflService.*
 import uk.gov.nationalarchives.*
@@ -214,10 +214,10 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
     val sqsClient = mock[DASQSClient[IO]]
     val responses = IO {
       messages.zipWithIndex.map { case (message, idx) =>
-        MessageResponse[Option[ReceivedSnsMessage]](s"handle$idx", Option(message))
+        MessageResponse[ReceivedSnsMessage](s"handle$idx", message)
       }
     }
-    when(sqsClient.receiveMessages[Option[ReceivedSnsMessage]](any[String], any[Int])(using any[Decoder[Option[ReceivedSnsMessage]]]))
+    when(sqsClient.receiveMessages[ReceivedSnsMessage](any[String], any[Int])(using any[Decoder[ReceivedSnsMessage]]))
       .thenReturn(responses)
     when(sqsClient.deleteMessage(any[String], any[String])).thenReturn(IO(DeleteMessageResponse.builder().build))
     sqsClient
@@ -282,11 +282,11 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
     private val sqsMessages: List[ReceivedSnsMessage] =
       typesOfSqsMessages.zipWithIndex.flatMap { case (entityType, index) =>
         entityType match { // create duplicates in order to test deduplication
-          case InformationObject => (1 to 2).map(_ => IoReceivedSnsMessage(ioId, s"${ioType.toLowerCase}:$ioId"))
+          case InformationObject => (1 to 2).map(_ => IoReceivedSnsMessage(ioId))
           case ContentObject =>
             val coId = coIds(index)
-            (1 to 2).map(_ => CoReceivedSnsMessage(coId, s"${coType.toLowerCase}:$coId"))
-          case unexpectedEntityType => throw new Exception(s"Unexpected EntityType $unexpectedEntityType!")
+            (1 to 2).map(_ => CoReceivedSnsMessage(coId))
+          case StructuralObject => (1 to 2).map(_ => SoReceivedSnsMessage(UUID.randomUUID))
         }
       }
     val sqsClient: DASQSClient[IO] = mockSqs(sqsMessages)
@@ -396,17 +396,17 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
     val ioId: UUID = UUID.randomUUID()
     val coId: UUID = UUID.randomUUID()
 
-    lazy val coMessage: CoReceivedSnsMessage = CoReceivedSnsMessage(coId, s"co:$coId")
-    lazy val ioMessage: IoReceivedSnsMessage = IoReceivedSnsMessage(ioId, s"io:$ioId")
+    lazy val coMessage: CoReceivedSnsMessage = CoReceivedSnsMessage(coId)
+    lazy val ioMessage: IoReceivedSnsMessage = IoReceivedSnsMessage(ioId)
     val sqsClient: DASQSClient[IO] = mock[DASQSClient[IO]]
     val entityClient: EntityClient[IO, Fs2Streams[IO]] = mock[EntityClient[IO, Fs2Streams[IO]]]
     val snsClient: DASNSClient[IO] = mock[DASNSClient[IO]]
 
-    val duplicatesIoMessageResponse: MessageResponse[Option[ReceivedSnsMessage]] =
-      MessageResponse[Option[ReceivedSnsMessage]]("receiptHandle1", Option(ioMessage))
+    val duplicatesIoMessageResponse: MessageResponse[ReceivedSnsMessage] =
+      MessageResponse[ReceivedSnsMessage]("receiptHandle1", ioMessage)
 
-    val duplicatesCoMessageResponses: MessageResponse[Option[ReceivedSnsMessage]] =
-      MessageResponse[Option[ReceivedSnsMessage]]("receiptHandle2", Option(coMessage))
+    val duplicatesCoMessageResponses: MessageResponse[ReceivedSnsMessage] =
+      MessageResponse[ReceivedSnsMessage]("receiptHandle2", coMessage)
 
     private val potentialParentRef = if parentRefExists then Some(ioId) else None
 


### PR DESCRIPTION
The CC process is only interested in IO and CO messages as there’s nothing we want to store about an SO.

The incoming message is returned as `Option[ReceivedSnsMessage]` where None indicates an SO.

The problem with this is that we then do `distinctBy` on this value which flattens all the SO values so that we only get the first one.

So when multiple SO messages come in, all but one are not being deleted.

The problem is mostly caused by using an `Option` to represent an SO message. I’ve realised now that this is silly and I should have an SoReceivedMessage case class to represent this.

We also weren't using the messageText parameter other than for deduping and we can use the ref for that as the odds for having the same uuid for a CO and an IO are small enough to ignore.
