### PR TITLE
Dr2 1873 support multiple fixities in custodial copy

### DIFF
--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/CustodialCopyObject.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/CustodialCopyObject.scala
@@ -8,7 +8,7 @@ import scala.xml.Elem
 sealed trait CustodialCopyObject {
   val destinationFilePath: String
   def id: UUID
-  def checksum: String
+  def checksums: List[Checksum]
   def name: String
   def sourceFilePath: IO[Path] = createDirectory.map(cd => Path(s"$cd/$name"))
   def tableItemIdentifier: String | UUID
@@ -21,7 +21,7 @@ object CustodialCopyObject {
   case class FileObject(
       id: UUID,
       name: String,
-      checksum: String,
+      checksums: List[Checksum],
       url: String,
       destinationFilePath: String,
       tableItemIdentifier: UUID
@@ -30,9 +30,11 @@ object CustodialCopyObject {
       id: UUID,
       repTypeGroup: Option[String],
       name: String,
-      checksum: String,
+      checksums: List[Checksum],
       metadata: Elem,
       destinationFilePath: String,
       tableItemIdentifier: String | UUID
   ) extends CustodialCopyObject
 }
+
+case class Checksum(algorithm: String, fingerprint: String)

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/OcflService.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/OcflService.scala
@@ -61,8 +61,7 @@ class OcflService(ocflRepository: OcflRepository, semaphore: Semaphore[IO]) {
             val potentialFile = Option(ocflObject.getFile(obj.destinationFilePath))
             potentialFile match {
               case Some(ocflFileObject) =>
-                val checksumUnchanged =
-                  Some(ocflFileObject.getFixity.get(DigestAlgorithm.fromOcflName("sha256"))).contains(obj.checksum)
+                val checksumUnchanged = isChecksumUnchanged(ocflFileObject.getFixity, obj.checksums)
                 if checksumUnchanged then missingAndChanged else (missingObjects, obj :: changedObjects)
               case None =>
                 (obj :: missingObjects, changedObjects) // Information Object exists but file doesn't
@@ -91,6 +90,16 @@ class OcflService(ocflRepository: OcflRepository, semaphore: Semaphore[IO]) {
       val (missingObjects, changedObjects) = missingAndChangedPair
       MissingAndChangedObjects(missingObjects, changedObjects)
     }
+
+  private def isChecksumUnchanged(fixitiesMap: java.util.Map[DigestAlgorithm, String], checksums: List[Checksum]): Boolean = {
+    if (fixitiesMap.size() != checksums.size) {
+      false
+    } else {
+      checksums.forall(eachChecksum =>
+        Some(fixitiesMap.get(DigestAlgorithm.fromOcflName(eachChecksum.algorithm.toLowerCase))).contains(eachChecksum.fingerprint)
+      )
+    }
+  }
 
   def getAllFilePathsOnAnObject(ioId: UUID): IO[List[String]] =
     IO.blocking(ocflRepository.getObject(ioId.toHeadVersion))

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
@@ -84,7 +84,7 @@ class Processor(
         ioRef,
         repType,
         fileName,
-        DigestUtils.sha256Hex(allMetadataAsXmlString),
+        List(Checksum("SHA256", DigestUtils.sha256Hex(allMetadataAsXmlString))),
         allMetadataAsXml,
         path,
         tableItemIdentifier
@@ -199,7 +199,7 @@ class Processor(
         FileObject(
           parentRef,
           bitStreamInfo.name,
-          bitStreamInfo.fixity.value,
+          bitStreamInfo.fixities.map(eachFixity => Checksum(eachFixity.algorithm, eachFixity.value)),
           bitStreamInfo.url,
           destinationFilePath,
           removeFileExtension(bitStreamInfo.name)

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/MainTest.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/MainTest.scala
@@ -48,7 +48,7 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
   ): List[Outcome[IO, Throwable, Unit]] = Main.runCustodialCopy(sqsClient, config, processor).compile.toList.unsafeRunSync().flatten
 
   "runCustodialCopy" should "(given an IO message with 'deleted' set to 'true') delete all objects underneath it" in {
-    val fixity = Fixity("SHA256", "")
+    val fixity = List(Fixity("SHA256", ""))
     val ioId = UUID.randomUUID()
     val bitStreamInfoList = Seq(
       BitStreamInfo("90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt", 1, "", fixity, 1, Original, None, Some(ioId)),
@@ -352,7 +352,7 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
         "90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt",
         1,
         "",
-        Fixity("SHA256", ""),
+        List(Fixity("SHA256", "")),
         1,
         Original,
         None,
@@ -375,7 +375,7 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
           "90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt",
           1,
           "",
-          Fixity("SHA256", ""),
+          List(Fixity("SHA256", "")),
           1,
           Original,
           None,
@@ -432,7 +432,7 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
           "90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt",
           1,
           "",
-          Fixity("SHA256", checksum),
+          List(Fixity("SHA256", checksum)),
           1,
           Original,
           None,
@@ -462,7 +462,7 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
             "90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt",
             1,
             "",
-            Fixity("SHA256", "DifferentContent"),
+            List(Fixity("SHA256", "DifferentContent")),
             1,
             Original,
             None,
@@ -489,7 +489,7 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
 
   "runCustodialCopy" should "write multiple bitstreams to the same version and to the correct location" in {
     val ioId = UUID.randomUUID()
-    val fixity = Fixity("SHA256", "")
+    val fixity = List(Fixity("SHA256", ""))
     val bitStreamInfoList = Seq(
       BitStreamInfo("90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt", 1, "", fixity, 1, Original, None, Some(ioId)),
       BitStreamInfo("90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt2", 1, "", fixity, 2, Derived, None, Some(ioId))
@@ -561,7 +561,7 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
             "90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt",
             1,
             "",
-            Fixity("SHA256", checksum),
+            List(Fixity("SHA256", checksum)),
             1,
             Original,
             None,
@@ -613,7 +613,7 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
           "90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt",
           1,
           "",
-          Fixity("SHA256", checksum),
+          List(Fixity("SHA256", checksum)),
           1,
           Original,
           None,

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/ProcessorTest.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/ProcessorTest.scala
@@ -226,7 +226,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
                 id,
                 Some("Preservation_1"),
                 "changed",
-                "checksum",
+                List(Checksum("sha256", "checksum")),
                 utils.ioConsolidatedMetadata,
                 "destinationPath",
                 "SourceIDValue"
@@ -265,7 +265,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
                 id,
                 Some("Preservation_1"),
                 "missing",
-                "checksum",
+                List(Checksum("sha256", "checksum")),
                 utils.ioConsolidatedMetadata,
                 "destinationPath",
                 "SourceIDValue"
@@ -302,7 +302,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
                 changedFileId,
                 Some("Preservation_1"),
                 "changed",
-                "checksum",
+                List(Checksum("sha256", "checksum")),
                 utils.ioConsolidatedMetadata,
                 "destinationPath2",
                 "SourceIDValue"
@@ -354,7 +354,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
                 missingFileId,
                 Some("Preservation_1"),
                 "missing",
-                "checksum",
+                List(Checksum("sha256", "checksum")),
                 utils.ioConsolidatedMetadata,
                 "destinationPath",
                 "SourceIDValue"

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/testUtils/ExternalServicesTestUtils.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/testUtils/ExternalServicesTestUtils.scala
@@ -125,11 +125,11 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
           combinedBitstreamInfoResponses.map { bitstreamInfo =>
             <Bitstream><Filename>{bitstreamInfo.name}</Filename><FileSize>{
               bitstreamInfo.fileSize
-            }</FileSize><Fixities><Fixity><FixityAlgorithmRef>{
-              bitstreamInfo.fixity.algorithm
-            }</FixityAlgorithmRef><FixityValue>{
-              bitstreamInfo.fixity.value
-            }</FixityValue></Fixity></Fixities></Bitstream>
+            }</FileSize><Fixities>{
+              bitstreamInfo.fixities.map(eachFixity =>
+                <Fixity><FixityAlgorithmRef>{eachFixity.algorithm.toUpperCase}</FixityAlgorithmRef><FixityValue>{eachFixity.value}</FixityValue></Fixity>
+              )
+            }</Fixities></Bitstream>
           },
           Seq(<Identifier><ApiId/><Type/><Value/><Entity/></Identifier>),
           Seq(<Link><Type/><FromEntity/><ToEntity/></Link>),
@@ -265,7 +265,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
           "90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt",
           1,
           "",
-          Fixity("SHA256", ""),
+          List(Fixity("SHA256", "")),
           1,
           Original,
           None,
@@ -340,9 +340,11 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
         "\n          ",
         <Bitstream><Filename>{bitstreamInfo.name}</Filename><FileSize>{
           bitstreamInfo.fileSize
-        }</FileSize><Fixities><Fixity><FixityAlgorithmRef>{
-          bitstreamInfo.fixity.algorithm
-        }</FixityAlgorithmRef><FixityValue>{bitstreamInfo.fixity.value}</FixityValue></Fixity></Fixities></Bitstream>
+        }</FileSize><Fixities>{
+          bitstreamInfo.fixities.map(eachFixity =>
+            <Fixity><FixityAlgorithmRef>{eachFixity.algorithm.toUpperCase}</FixityAlgorithmRef><FixityValue>{eachFixity.value}</FixityValue></Fixity>
+          )
+        }</Fixities></Bitstream>
       )
     }
     private val coMetadataInRepo =
@@ -439,7 +441,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
       "90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt",
       1,
       "url",
-      Fixity("sha256", "checksum"),
+      List(Fixity("sha256", "checksum")),
       genVersion,
       genType,
       Some("CoTitle"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   lazy val log4jTemplateJson = "org.apache.logging.log4j" % "log4j-layout-template-json" % logbackVersion
   lazy val mockito = "org.scalatestplus" %% "mockito-5-10" % s"$scalaTestVersion.0"
   lazy val ocfl = "io.ocfl" % "ocfl-java-core" % "2.2.1"
-  lazy val preservicaClient = "uk.gov.nationalarchives" %% "preservica-client-fs2" % "0.0.94"
+  lazy val preservicaClient = "uk.gov.nationalarchives" %% "preservica-client-fs2" % "0.0.96"
   lazy val pureConfigCatsEffect = "com.github.pureconfig" %% "pureconfig-cats-effect" % pureConfigVersion
   lazy val pureConfig = "com.github.pureconfig" %% "pureconfig-core" % pureConfigVersion
   lazy val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.18.0"


### PR DESCRIPTION
Changes to make custodial copy deal successfully with multiple checksums from ingest