### PR TITLE
Poll every 10 seconds

### DIFF
--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Main.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Main.scala
@@ -69,7 +69,7 @@ object Main extends IOApp {
       sns = DASNSClient[IO]()
       processor <- Processor(config, sqs, service, client, sns)
       _ <- {
-        Stream.fixedRateStartImmediately[IO](20.seconds) >>
+        Stream.fixedRateStartImmediately[IO](10.seconds) >>
           runCustodialCopy(sqs, config, processor)
             .handleErrorWith(err => Stream.eval(semaphore.release >> logError(err)))
       }.compile.drain


### PR DESCRIPTION
If we get a backlog in the queue, running every 20 seconds is too slow.

This might cause it to run out of memory or similar but it's worth a
try.
