### PR TITLE
DR2-1890 Use mutable head and other fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,23 @@ The queue sends messages in this format:
 ```json
 {
   "id": "io:1b9555dd-43b7-4681-9b0d-85ebe951ca02",
-  "deleted": Boolean
+  "deleted": false
 }
 ```
 
 The prefix of the id can be `io`, `co` or `so` depending on the entity type; they are dealt with differently.
 Messages are deduped before they are processed.
 The "deleted" entry refers to the status on Preservica; the value could be `true` or `false`.
+
+#### Processing incoming messages based on message group ID.
+
+The SQS queue which feeds this process is a FIFO queue. Each message has a UUID as a message group ID. This is the IO UUID for an IO message or the parent of the CO for a CO message.
+
+The process groups by the message group ID. Each group id corresponds to an OCFL object (which may not exist yet)
+
+All updates for a single group of messages with the same group id are staged in OCFL. This allows us to write multiple changes without creating new versions.
+
+Once all messages are processed, we commit the changes to that OCFL object which writes the version permanently.
 
 #### Handling Information Object (IO) messages, if entity has not been deleted
 

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Main.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Main.scala
@@ -111,7 +111,7 @@ object Main extends IOApp {
       allFibers = fibersForNonDeletedEntities ++ fibersForDeletedEntities
       allFiberResults = ndeFiberResults ++ deFiberResults
 
-      _ <- processor.commit(UUID.fromString(groupId)).voidError
+      _ <- processor.commit(UUID.fromString(groupId))
       _ <- logger.info(s"${allFiberResults.count(_.isSuccess)} messages out of ${allFibers.length} unique messages processed successfully")
       _ <- logger.info(s"${allFiberResults.count(_.isError)} messages out of ${allFibers.length} unique messages failed")
 

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Main.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Main.scala
@@ -111,7 +111,7 @@ object Main extends IOApp {
       allFibers = fibersForNonDeletedEntities ++ fibersForDeletedEntities
       allFiberResults = ndeFiberResults ++ deFiberResults
 
-      _ <- processor.commit(UUID.fromString(groupId))
+      _ <- processor.commitStagedChanges(UUID.fromString(groupId))
       _ <- logger.info(s"${allFiberResults.count(_.isSuccess)} messages out of ${allFibers.length} unique messages processed successfully")
       _ <- logger.info(s"${allFiberResults.count(_.isError)} messages out of ${allFibers.length} unique messages failed")
 

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/OcflService.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/OcflService.scala
@@ -19,7 +19,7 @@ import scala.jdk.FunctionConverters.*
 
 class OcflService(ocflRepository: MutableOcflRepository, semaphore: Semaphore[IO]) {
 
-  def commit(id: UUID): IO[Unit] =
+  def commitStagedChanges(id: UUID): IO[Unit] =
     IO.whenA(ocflRepository.hasStagedChanges(id.toString)) {
       IO.blocking {
         ocflRepository.commitStagedChanges(id.toString, ocflRepository.getObject(id.toHeadVersion).getVersionInfo)

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
@@ -318,7 +318,7 @@ class Processor(
       _ <- logger.info(s"${snsMessages.length} 'created/updated objects' messages published to SNS")
     } yield messageResponse.message.ref
 
-  def commit(id: UUID): IO[Unit] = ocflService.commit(id).void
+  def commit(id: UUID): IO[Unit] = ocflService.commit(id)
 }
 object Processor {
   def apply(

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
@@ -318,7 +318,7 @@ class Processor(
       _ <- logger.info(s"${snsMessages.length} 'created/updated objects' messages published to SNS")
     } yield messageResponse.message.ref
 
-  def commit(id: UUID): IO[Unit] = ocflService.commit(id)
+  def commitStagedChanges(id: UUID): IO[Unit] = ocflService.commitStagedChanges(id)
 }
 object Processor {
   def apply(

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/OcflServiceTest.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/OcflServiceTest.scala
@@ -6,9 +6,9 @@ import cats.effect.unsafe.implicits.global
 import io.ocfl.api.exception.{CorruptObjectException, NotFoundException}
 import io.ocfl.api.io.FixityCheckInputStream
 import io.ocfl.api.model.*
-import io.ocfl.api.{OcflFileRetriever, OcflObjectUpdater, OcflOption, MutableOcflRepository}
+import io.ocfl.api.{MutableOcflRepository, OcflFileRetriever, OcflObjectUpdater, OcflOption}
 import org.mockito.ArgumentMatchers.any
-import org.mockito.ArgumentCaptor
+import org.mockito.{ArgumentCaptor, ArgumentMatchers}
 import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito.{doNothing, times, verify, when}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -284,5 +284,47 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
     verify(updater, times(2)).removeFile(pathsToDelete.capture)
 
     pathsToDelete.getAllValues.asScala.toList should equal(List(destinationPath, "destinationPath2"))
+  }
+
+  "commitStagedChanges" should "make a call to the repository commit if there are staged changes" in {
+    val id = UUID.randomUUID
+    val ocflRepository = mock[MutableOcflRepository]
+    val commitIdCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
+    val versionInfoCaptor: ArgumentCaptor[VersionInfo] = ArgumentCaptor.forClass(classOf[VersionInfo])
+    val versionInfoReturnValue = new VersionInfo()
+    versionInfoReturnValue.setUser("user", "address")
+    versionInfoReturnValue.setMessage("message")
+    val versionDetails = new VersionDetails()
+    val v1 = VersionNum.V1
+    versionDetails.setObjectVersionId(ObjectVersionId.version(id.toString, v1))
+    versionDetails.setVersionInfo(versionInfoReturnValue)
+    val objectVersion = new OcflObjectVersion(versionDetails, java.util.Map.of())
+
+    when(ocflRepository.getObject(ArgumentMatchers.eq(ObjectVersionId.head(id.toString)))).thenReturn(objectVersion)
+
+    when(ocflRepository.commitStagedChanges(commitIdCaptor.capture, versionInfoCaptor.capture())).thenReturn(ObjectVersionId.version(id.toString, 1))
+
+    when(ocflRepository.hasStagedChanges(id.toString)).thenReturn(true)
+
+    val service = new OcflService(ocflRepository, semaphore)
+
+    service.commitStagedChanges(id).unsafeRunSync()
+
+    commitIdCaptor.getValue should equal(id.toString)
+    val capturedVersionInfo = versionInfoCaptor.getValue
+    capturedVersionInfo.getUser.getName should equal("user")
+    capturedVersionInfo.getUser.getAddress should equal("address")
+    capturedVersionInfo.getMessage should equal("message")
+  }
+
+  "commitStagedChanges" should "not commit to the repository if there are no staged changes" in {
+    val id = UUID.randomUUID
+    val ocflRepository = mock[MutableOcflRepository]
+    when(ocflRepository.hasStagedChanges(id.toString)).thenReturn(false)
+
+    new OcflService(ocflRepository, semaphore).commitStagedChanges(id).unsafeRunSync()
+
+    verify(ocflRepository, times(0)).getObject(any[ObjectVersionId])
+    verify(ocflRepository, times(0)).commitStagedChanges(any[String], any[VersionInfo])
   }
 }

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/OcflServiceTest.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/OcflServiceTest.scala
@@ -6,7 +6,7 @@ import cats.effect.unsafe.implicits.global
 import io.ocfl.api.exception.{CorruptObjectException, NotFoundException}
 import io.ocfl.api.io.FixityCheckInputStream
 import io.ocfl.api.model.*
-import io.ocfl.api.{OcflFileRetriever, OcflObjectUpdater, OcflOption, OcflRepository}
+import io.ocfl.api.{OcflFileRetriever, OcflObjectUpdater, OcflOption, MutableOcflRepository}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentCaptor
 import org.scalatestplus.mockito.MockitoSugar
@@ -41,7 +41,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
     override def retrieveRange(startPosition: lang.Long, endPosition: lang.Long): InputStream = new ByteArrayInputStream("".getBytes)
 
   def mockGetObjectResponse(
-      ocflRepository: OcflRepository,
+      ocflRepository: MutableOcflRepository,
       id: UUID,
       ocflChecksum: List[Checksum],
       destinationPath: String
@@ -59,7 +59,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
 
   "getMissingAndChangedObjects" should "return 1 missing DR object and 0 changed DR objects if the repository doesn't contain the OCFL object" in {
     val id = UUID.randomUUID()
-    val ocflRepository = mock[OcflRepository]
+    val ocflRepository = mock[MutableOcflRepository]
     when(ocflRepository.getObject(any[ObjectVersionId])).thenThrow(new NotFoundException)
 
     val service = new OcflService(ocflRepository, semaphore)
@@ -79,7 +79,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
   "getMissingAndChangedObjects" should "return 1 missing DR object and 0 changed DR objects if the repository contains the OCFL object " +
     "but doesn't contain the file" in {
       val id = UUID.randomUUID()
-      val ocflRepository = mock[OcflRepository]
+      val ocflRepository = mock[MutableOcflRepository]
       mockGetObjectResponse(ocflRepository, id, checksums, destinationPath)
 
       val service = new OcflService(ocflRepository, semaphore)
@@ -99,7 +99,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
   "getMissingAndChangedObjects" should "return 0 missing DR objects and 0 changed DR objects if the repository contains the DR object " +
     "but the checksums match" in {
       val id = UUID.randomUUID()
-      val ocflRepository = mock[OcflRepository]
+      val ocflRepository = mock[MutableOcflRepository]
       mockGetObjectResponse(ocflRepository, id, checksums, destinationPath)
 
       val service = new OcflService(ocflRepository, semaphore)
@@ -118,7 +118,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
   "getMissingAndChangedObjects" should "return 0 missing DR objects and 1 changed DR objects if the repository contains the DR object " +
     "but the checksums don't match" in {
       val id = UUID.randomUUID()
-      val ocflRepository = mock[OcflRepository]
+      val ocflRepository = mock[MutableOcflRepository]
       mockGetObjectResponse(ocflRepository, id, checksums, destinationPath)
 
       val service = new OcflService(ocflRepository, semaphore)
@@ -136,7 +136,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
 
   "getMissingAndChangedObjects" should "throw an exception if 'ocflRepository.getObject' returns an unexpected Exception" in {
     val id = UUID.randomUUID()
-    val ocflRepository = mock[OcflRepository]
+    val ocflRepository = mock[MutableOcflRepository]
     when(ocflRepository.getObject(any[ObjectVersionId])).thenThrow(new RuntimeException("unexpected Exception"))
 
     val service = new OcflService(ocflRepository, semaphore)
@@ -154,7 +154,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
 
   "getMissingAndChangedObjects" should "purge the failed object if there is a CorruptedObjectException and rethrow the error" in {
     val id = UUID.randomUUID()
-    val ocflRepository = mock[OcflRepository]
+    val ocflRepository = mock[MutableOcflRepository]
     val objectIdCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
     when(ocflRepository.getObject(any[ObjectVersionId])).thenThrow(new CorruptObjectException())
     doNothing().when(ocflRepository).purgeObject(objectIdCaptor.capture())
@@ -175,14 +175,14 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
 
   "createObjects" should "create DR objects in the OCFL repository" in {
     val id = UUID.randomUUID()
-    val ocflRepository = mock[OcflRepository]
+    val ocflRepository = mock[MutableOcflRepository]
     val objectVersionCaptor: ArgumentCaptor[ObjectVersionId] = ArgumentCaptor.forClass(classOf[ObjectVersionId])
     val updater = mock[OcflObjectUpdater]
     val sourceNioFilePathToAdd: ArgumentCaptor[Path] = ArgumentCaptor.forClass(classOf[Path])
     val destinationPathToAdd: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
     val optionToAdd: ArgumentCaptor[OcflOption] = ArgumentCaptor.forClass(classOf[OcflOption])
 
-    when(ocflRepository.updateObject(objectVersionCaptor.capture, any[VersionInfo], any[Consumer[OcflObjectUpdater]]))
+    when(ocflRepository.stageChanges(objectVersionCaptor.capture, any[VersionInfo], any[Consumer[OcflObjectUpdater]]))
       .thenAnswer { invocation =>
         val consumer = invocation.getArgument[Consumer[OcflObjectUpdater]](2)
         consumer.accept(updater)
@@ -205,7 +205,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
 
   "getAllFilePathsOnAnObject" should "throw an exception if the object to be deleted does not exist" in {
     val id = UUID.randomUUID()
-    val ocflRepository = mock[OcflRepository]
+    val ocflRepository = mock[MutableOcflRepository]
     when(ocflRepository.getObject(any[ObjectVersionId])).thenThrow(new NotFoundException)
 
     val service = new OcflService(ocflRepository, semaphore)
@@ -219,7 +219,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
 
   "getAllFilePathsOnAnObject" should "return a path if the repository contains the OCFL object" in {
     val id = UUID.randomUUID()
-    val ocflRepository = mock[OcflRepository]
+    val ocflRepository = mock[MutableOcflRepository]
     mockGetObjectResponse(ocflRepository, id, checksums, destinationPath)
 
     val service = new OcflService(ocflRepository, semaphore)
@@ -230,7 +230,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
 
   "getAllFilePathsOnAnObject" should "throw an exception if 'ocflRepository.getObject' returns an unexpected Exception" in {
     val id = UUID.randomUUID()
-    val ocflRepository = mock[OcflRepository]
+    val ocflRepository = mock[MutableOcflRepository]
     when(ocflRepository.getObject(any[ObjectVersionId])).thenThrow(new RuntimeException("unexpected Exception"))
 
     val service = new OcflService(ocflRepository, semaphore)
@@ -246,7 +246,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
 
   "getAllFilePathsOnAnObject" should "purge the failed object if there is a CorruptedObjectException and rethrow the error" in {
     val id = UUID.randomUUID()
-    val ocflRepository = mock[OcflRepository]
+    val ocflRepository = mock[MutableOcflRepository]
     val objectIdCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
     when(ocflRepository.getObject(any[ObjectVersionId])).thenThrow(new CorruptObjectException())
     doNothing().when(ocflRepository).purgeObject(objectIdCaptor.capture())
@@ -265,12 +265,12 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
 
   "deleteObjects" should "make the call to delete CC objects in the OCFL repository" in {
     val id = UUID.randomUUID()
-    val ocflRepository = mock[OcflRepository]
+    val ocflRepository = mock[MutableOcflRepository]
     val objectVersionCaptor: ArgumentCaptor[ObjectVersionId] = ArgumentCaptor.forClass(classOf[ObjectVersionId])
     val updater = mock[OcflObjectUpdater]
     val pathsToDelete: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
 
-    when(ocflRepository.updateObject(objectVersionCaptor.capture, any[VersionInfo], any[Consumer[OcflObjectUpdater]]))
+    when(ocflRepository.stageChanges(objectVersionCaptor.capture, any[VersionInfo], any[Consumer[OcflObjectUpdater]]))
       .thenAnswer { invocation =>
         val consumer = invocation.getArgument[Consumer[OcflObjectUpdater]](2)
         consumer.accept(updater)

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/ProcessorTest.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/ProcessorTest.scala
@@ -62,7 +62,6 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
       createdIdSourceAndDestinationPathAndId = Nil,
       drosToLookup = Nil,
       snsMessagesToSend = Nil,
-      receiptHandles = Nil,
       destinationPathsToDelete = Nil
     )
   }
@@ -98,8 +97,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
           s"$parentRef/Preservation_1/$id/original/g1/90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt",
           s"$parentRef/Preservation_1/$id/CO_Metadata.xml"
         )
-      ),
-      receiptHandles = List("receiptHandle2")
+      )
     )
   }
 
@@ -119,8 +117,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
       entityTypesToGetMetadataFrom = Nil,
       xmlRequestsToValidate = Nil,
       createdIdSourceAndDestinationPathAndId = Nil,
-      drosToLookup = Nil,
-      receiptHandles = Nil
+      drosToLookup = Nil
     )
   }
 
@@ -150,8 +147,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
       idsOfEntityToGetMetadataFrom = Nil,
       entityTypesToGetMetadataFrom = Nil,
       xmlRequestsToValidate = Nil,
-      drosToLookup = Nil,
-      receiptHandles = Nil
+      drosToLookup = Nil
     )
   }
 
@@ -172,8 +168,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
       repIndexes = Nil,
       drosToLookup = List(
         List(s"$parentRef/IO_Metadata.xml")
-      ),
-      receiptHandles = List(1).map(n => s"receiptHandle$n")
+      )
     )
   }
 
@@ -196,8 +191,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
           s"$parentRef/Preservation_1/$id/original/g1/90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt",
           s"$parentRef/Preservation_1/$id/CO_Metadata.xml"
         )
-      ),
-      receiptHandles = List(2).map(n => s"receiptHandle$n")
+      )
     )
   }
 
@@ -314,6 +308,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
 
     val response: MessageResponse[ReceivedSnsMessage] = MessageResponse[ReceivedSnsMessage](
       "receiptHandle2",
+      Option(changedFileId.toString),
       IoReceivedSnsMessage(changedFileId, false)
     )
 
@@ -335,8 +330,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
       ),
       snsMessagesToSend = List(
         SendSnsMessage(InformationObject, changedFileId, Metadata, Updated, "SourceIDValue")
-      ),
-      receiptHandles = List("receiptHandle2")
+      )
     )
   }
 
@@ -368,6 +362,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
     val response: MessageResponse[ReceivedSnsMessage] =
       MessageResponse[ReceivedSnsMessage](
         "receiptHandle1",
+        Option(missingFileId.toString),
         IoReceivedSnsMessage(missingFileId, false)
       )
     utils.processor.process(response, false).unsafeRunSync()
@@ -388,8 +383,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
       ),
       snsMessagesToSend = List(
         SendSnsMessage(InformationObject, missingFileId, Metadata, Created, "SourceIDValue")
-      ),
-      receiptHandles = List("receiptHandle1")
+      )
     )
   }
 
@@ -436,8 +430,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
           <EventAction commandType="command_create"><Event type="Ingest"><Ref/><Date/><User/></Event><Date/><Entity>a9e1cae8-ea06-4157-8dd4-82d0525b031c</Entity></EventAction>
         </XIP>
       ),
-      drosToLookup = Nil,
-      receiptHandles = Nil
+      drosToLookup = Nil
     )
   }
 
@@ -450,8 +443,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
 
     utils.verifyCallsAndArguments(
       repTypes = Nil,
-      repIndexes = Nil,
-      receiptHandles = Nil
+      repIndexes = Nil
     )
   }
 }

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/testUtils/ExternalServicesTestUtils.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/testUtils/ExternalServicesTestUtils.scala
@@ -510,6 +510,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
     private val messagesCaptor: ArgumentCaptor[List[SendSnsMessage]] =
       ArgumentCaptor.forClass(classOf[List[SendSnsMessage]])
     private val receiptHandleCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
+    val commitIdCaptor: ArgumentCaptor[UUID] = ArgumentCaptor.forClass(classOf[UUID])
 
     private def mockOcflService(
         missingObjects: List[CustodialCopyObject] = Nil,
@@ -528,7 +529,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
       when(ocflService.createObjects(any[List[IdWithSourceAndDestPaths]])).thenReturn(IO.unit)
       when(ocflService.getAllFilePathsOnAnObject(any[UUID])).thenReturn(IO.pure(pathsOfObjects))
       when(ocflService.deleteObjects(any[UUID], any[List[String]])).thenReturn(IO.unit)
-
+      when(ocflService.commitStagedChanges(commitIdCaptor.capture)).thenReturn(IO.unit)
       ocflService
     }
 

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/testUtils/ExternalServicesTestUtils.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/testUtils/ExternalServicesTestUtils.scala
@@ -6,7 +6,7 @@ import cats.effect.unsafe.implicits.global
 import fs2.Stream
 import io.circe.{Decoder, Encoder}
 import io.ocfl.api.model.DigestAlgorithm
-import io.ocfl.api.{OcflConfig, OcflRepository}
+import io.ocfl.api.{OcflConfig, MutableOcflRepository}
 import io.ocfl.core.OcflRepositoryBuilder
 import io.ocfl.core.extension.storage.layout.config.HashedNTupleLayoutConfig
 import io.ocfl.core.storage.OcflStorageBuilder
@@ -135,7 +135,8 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
           Seq(<Link><Type/><FromEntity/><ToEntity/></Link>),
           metadataElems,
           Seq(
-            <EventAction commandType="command_create"><Event type="Ingest"><Ref/><Date>2024-05-31T11:54:20.528Z</Date><User/></Event><Date>2024-05-31T11:54:20.528Z</Date><Entity>a9e1cae8-ea06-4157-8dd4-82d0525b031c</Entity><SerialisedCommand/></EventAction>
+            <EventAction commandType="command_create"><Event type="Ingest"><Ref/><Date>2024-05-31T11:54:20.528Z</Date><User/></Event><Date>2024-05-31T11:54:20.528Z</Date><Entity>a9e1cae8-ea06-4157-8dd4-82d0525b031c</Entity><SerialisedCommand/></EventAction>,
+            <EventAction commandType="command_download"></EventAction>
           )
         )
       )
@@ -180,7 +181,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
   private def createExistingMetadataEntryInRepo(
       id: UUID,
       entityType: String,
-      repo: OcflRepository,
+      repo: MutableOcflRepository,
       existingMetadata: Elem,
       destinationPath: String
   ) = {
@@ -190,7 +191,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
 
   private def addFileToRepo(
       id: UUID,
-      repo: OcflRepository,
+      repo: MutableOcflRepository,
       bodyAsString: String,
       sourceFilePath: String,
       destinationPath: String
@@ -219,14 +220,14 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
       }).asJava)
       .prettyPrintJson()
       .workDir(workDir)
-      .build()
+      .buildMutable()
   }
 
-  private def mockSqs(messages: List[ReceivedSnsMessage]): DASQSClient[IO] = {
+  private def mockSqs(messages: List[ReceivedSnsMessage], messageGroupId: String): DASQSClient[IO] = {
     val sqsClient = mock[DASQSClient[IO]]
     val responses = IO {
       messages.zipWithIndex.map { case (message, idx) =>
-        MessageResponse[ReceivedSnsMessage](s"handle$idx", message)
+        MessageResponse[ReceivedSnsMessage](s"handle$idx", Option(messageGroupId), message)
       }
     }
     when(sqsClient.receiveMessages[ReceivedSnsMessage](any[String], any[Int])(using any[Decoder[ReceivedSnsMessage]]))
@@ -253,7 +254,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
 
   class MainTestUtils(
       typesOfSqsMsgAndDeletionStatus: List[(EntityType, Boolean)] = List((InformationObject, false)),
-      objectVersion: Int = 1,
+      objectVersion: Int = 2,
       typesOfMetadataFilesInRepo: List[EntityType] = Nil,
       fileContentToWriteToEachFileInRepo: List[String] = Nil,
       entityDeleted: Boolean = false,
@@ -289,7 +290,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
     val coId3: UUID = if bitstreamInfoResponsesWithSameName.nonEmpty then coId1 else UUID.randomUUID()
     val ioId: UUID = bitstreamInfo1Responses.headOption.flatMap(_.parentRef).getOrElse(UUID.randomUUID())
     lazy val repoDir: Path = Files.createTempDirectory("repo")
-    lazy val repo: OcflRepository = createTestRepo(repoDir)
+    lazy val repo: MutableOcflRepository = createTestRepo(repoDir)
 
     private val coIds: Seq[UUID] = List(coId1, coId2, coId3, coId1)
     private val sqsMessages: List[ReceivedSnsMessage] =
@@ -302,7 +303,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
           case StructuralObject => (1 to 2).map(_ => SoReceivedSnsMessage(UUID.randomUUID, hasBeenDeleted))
         }
       }
-    val sqsClient: DASQSClient[IO] = mockSqs(sqsMessages)
+    val sqsClient: DASQSClient[IO] = mockSqs(sqsMessages, ioId.toString)
     val snsClient: DASNSClient[IO] = mockSns()
 
     lazy val expectedIoMetadataFileDestinationPath: String = metadataFile(ioId, ioType)
@@ -392,7 +393,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
     val xmlValidator: ValidateXmlAgainstXsd[IO] = ValidateXmlAgainstXsd[IO](XipXsdSchemaV7)
     val processor = new Processor(config, sqsClient, ocflService, preservicaClient, xmlValidator, snsClient)
 
-    def latestObjectVersion(repo: OcflRepository, id: UUID): Long =
+    def latestObjectVersion(repo: MutableOcflRepository, id: UUID): Long =
       repo.getObject(id.toHeadVersion).getObjectVersionId.getVersionNum.getVersionNum
 
     private val potentialObjectVersion: Try[Long] = Try(latestObjectVersion(repo, ioId))
@@ -427,13 +428,13 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
     val snsClient: DASNSClient[IO] = mock[DASNSClient[IO]]
 
     val duplicatesSoMessageResponse: MessageResponse[ReceivedSnsMessage] =
-      MessageResponse[ReceivedSnsMessage]("receiptHandle0", soMessage)
+      MessageResponse[ReceivedSnsMessage]("receiptHandle0", Option(soMessage.ref.toString), soMessage)
 
     val duplicatesIoMessageResponse: MessageResponse[ReceivedSnsMessage] =
-      MessageResponse[ReceivedSnsMessage]("receiptHandle1", ioMessage)
+      MessageResponse[ReceivedSnsMessage]("receiptHandle1", Option(ioMessage.ref.toString), ioMessage)
 
     val duplicatesCoMessageResponses: MessageResponse[ReceivedSnsMessage] =
-      MessageResponse[ReceivedSnsMessage]("receiptHandle2", coMessage)
+      MessageResponse[ReceivedSnsMessage]("receiptHandle2", Option(coMessage.ref.toString), coMessage)
 
     private val potentialParentRef = if parentRefExists then Some(ioId) else None
 
@@ -488,7 +489,8 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
     private val linksFromApi = Seq(<Link><Type/><FromEntity/><ToEntity/></Link>)
     private val eventActionFromApi =
       Seq(
-        <EventAction commandType="command_create"><Event type="Ingest"><Ref/><Date>2024-05-31T11:54:20.528Z</Date><User/></Event><Date>2024-05-31T11:54:20.528Z</Date><Entity>a9e1cae8-ea06-4157-8dd4-82d0525b031c</Entity><SerialisedCommand/></EventAction>
+        <EventAction commandType="command_create"><Event type="Ingest"><Ref/><Date>2024-05-31T11:54:20.528Z</Date><User/></Event><Date>2024-05-31T11:54:20.528Z</Date><Entity>a9e1cae8-ea06-4157-8dd4-82d0525b031c</Entity><SerialisedCommand/></EventAction>,
+        <EventAction commandType="command_download"></EventAction>
       )
 
     private val getBitstreamsCoIdCaptor: ArgumentCaptor[UUID] = ArgumentCaptor.forClass(classOf[UUID])
@@ -497,7 +499,6 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
     private val repTypeCaptor: ArgumentCaptor[RepresentationType] = ArgumentCaptor.forClass(classOf[RepresentationType])
     private val repIndexCaptor: ArgumentCaptor[Int] = ArgumentCaptor.forClass(classOf[Int])
 
-    private val queueUrlCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
     private val idWithSourceAndDestPathsCaptor: ArgumentCaptor[List[IdWithSourceAndDestPaths]] =
       ArgumentCaptor.forClass(classOf[List[IdWithSourceAndDestPaths]])
     private val metadataXmlStringToValidate: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
@@ -623,8 +624,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
         createdIdSourceAndDestinationPathAndId: List[List[IdWithSourceAndDestPaths]] = Nil,
         drosToLookup: List[List[String]] = List(List(s"$ioId/IO_Metadata.xml")),
         destinationPathsToDelete: List[String] = Nil,
-        snsMessagesToSend: List[SendSnsMessage] = Nil,
-        receiptHandles: List[String] = List("receiptHandle1")
+        snsMessagesToSend: List[SendSnsMessage] = Nil
     ): Assertion = {
 
       verify(entityClient, times(numOfGetBitstreamInfoCalls)).getBitstreamInfo(getBitstreamsCoIdCaptor.capture)
@@ -646,8 +646,6 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
       val numOfTimesToDeleteObjects = if destinationPathsToDelete.nonEmpty then 1 else 0
       verify(ocflService, times(numOfTimesToDeleteObjects))
         .deleteObjects(ioToDeleteObjectsFromCaptor.capture(), pathsToDeleteCaptor.capture())
-      verify(sqsClient, times(receiptHandles.length))
-        .deleteMessage(queueUrlCaptor.capture, receiptHandleCaptor.capture)
 
       val numOfTimesSnsMsgShouldBeSent =
         if (snsMessagesToSend.nonEmpty || createdIdSourceAndDestinationPathAndId.flatten.nonEmpty) 1 else 0
@@ -671,9 +669,6 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
 
       repTypeCaptor.getAllValues.asScala.toList should equal(repTypes)
       repIndexCaptor.getAllValues.asScala.toList should equal(repIndexes)
-
-      queueUrlCaptor.getAllValues.asScala.toList should equal(List.fill(receiptHandles.length)("queueUrl"))
-      receiptHandleCaptor.getAllValues.asScala.toList should equal(receiptHandles)
 
       val expectedIdsWithSourceAndDestPath = createdIdSourceAndDestinationPathAndId.flatten
       idWithSourceAndDestPathsCaptor.getAllValues.asScala.toList.flatten.zipWithIndex.foreach { case (capturedIdWithSourceAndDestPath, index) =>

--- a/custodial-copy-db-builder/src/test/scala/uk/gov/nationalarchives/builder/BuilderSpec.scala
+++ b/custodial-copy-db-builder/src/test/scala/uk/gov/nationalarchives/builder/BuilderSpec.scala
@@ -32,7 +32,7 @@ class BuilderSpec extends AnyFlatSpec:
         assert(files.map(_.id).sorted == ids.sorted)
       }
 
-    val messages = List(MessageResponse[Message]("", Message(idOne)), MessageResponse[Message]("", Message(idTwo)))
+    val messages = List(MessageResponse[Message]("", None, Message(idOne)), MessageResponse[Message]("", None, Message(idTwo)))
     Builder[IO].run(messages).unsafeRunSync()
   }
 

--- a/custodial-copy-db-builder/src/test/scala/uk/gov/nationalarchives/builder/MainSpec.scala
+++ b/custodial-copy-db-builder/src/test/scala/uk/gov/nationalarchives/builder/MainSpec.scala
@@ -49,7 +49,7 @@ class MainSpec extends AnyFlatSpec with BeforeAndAfterEach with BeforeAndAfterAl
     .endpointOverride(URI.create("http://localhost:9001"))
     .httpClient(httpClient)
     .build()
-  val daSQSClient = new DASQSClient[IO](sqsClient)
+  val daSQSClient: DASQSClient[IO] = DASQSClient[IO](sqsClient)
 
   "runBuilder" should "write the correct items to the database for multiple content objects" in {
     val id = UUID.randomUUID
@@ -181,7 +181,9 @@ class MainSpec extends AnyFlatSpec with BeforeAndAfterEach with BeforeAndAfterAl
 
     val serveEvents = sqsServer.getAllServeEvents.asScala.toList
 
-    serveEvents.last.getRequest.getBodyAsString should equal("""{"QueueUrl":"http://localhost:9001","MaxNumberOfMessages":10}""")
+    serveEvents.last.getRequest.getBodyAsString should equal(
+      """{"QueueUrl":"http://localhost:9001","MessageSystemAttributeNames":["MessageGroupId"],"MaxNumberOfMessages":10}"""
+    )
     serveEvents.head.getRequest.getBodyAsString should equal("""{"QueueUrl":"http://localhost:9001","ReceiptHandle":"A"}""")
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,6 +1,6 @@
 import sbt.*
 object Dependencies {
-  private lazy val daAwsClientsVersion = "0.1.83"
+  private lazy val daAwsClientsVersion = "0.1.90-SNAPSHOT"
   private lazy val logbackVersion = "2.24.0"
   private lazy val log4CatsVersion = "2.7.0"
   private lazy val pureConfigVersion = "0.17.7"
@@ -16,7 +16,7 @@ object Dependencies {
   lazy val log4jTemplateJson = "org.apache.logging.log4j" % "log4j-layout-template-json" % logbackVersion
   lazy val mockito = "org.scalatestplus" %% "mockito-5-10" % s"$scalaTestVersion.0"
   lazy val ocfl = "io.ocfl" % "ocfl-java-core" % "2.2.1"
-  lazy val preservicaClient = "uk.gov.nationalarchives" %% "preservica-client-fs2" % "0.0.99"
+  lazy val preservicaClient = "uk.gov.nationalarchives" %% "preservica-client-fs2" % "0.0.101-SNAPSHOT"
   lazy val pureConfigCatsEffect = "com.github.pureconfig" %% "pureconfig-cats-effect" % pureConfigVersion
   lazy val pureConfig = "com.github.pureconfig" %% "pureconfig-core" % pureConfigVersion
   lazy val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.18.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,6 +1,6 @@
 import sbt.*
 object Dependencies {
-  private lazy val daAwsClientsVersion = "0.1.90-SNAPSHOT"
+  private lazy val daAwsClientsVersion = "0.1.90"
   private lazy val logbackVersion = "2.24.0"
   private lazy val log4CatsVersion = "2.7.0"
   private lazy val pureConfigVersion = "0.17.7"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   lazy val log4jTemplateJson = "org.apache.logging.log4j" % "log4j-layout-template-json" % logbackVersion
   lazy val mockito = "org.scalatestplus" %% "mockito-5-10" % s"$scalaTestVersion.0"
   lazy val ocfl = "io.ocfl" % "ocfl-java-core" % "2.2.1"
-  lazy val preservicaClient = "uk.gov.nationalarchives" %% "preservica-client-fs2" % "0.0.101-SNAPSHOT"
+  lazy val preservicaClient = "uk.gov.nationalarchives" %% "preservica-client-fs2" % "0.0.102"
   lazy val pureConfigCatsEffect = "com.github.pureconfig" %% "pureconfig-cats-effect" % pureConfigVersion
   lazy val pureConfig = "com.github.pureconfig" %% "pureconfig-core" % pureConfigVersion
   lazy val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.18.1"


### PR DESCRIPTION
There are a few changes here

The first is the change to use the FIFO queue and the mutable head.
There is a description in the README as to how this works.

The second is to filter out any event actions from Preservica for
command_download. When this process downloads the file for the first
time, it will create another two versions because the download is appended to
the event actions and this changes the checksum of both the IO and CO
metadata. This is a bit silly.

The third is that there's another bug which I thought I'd fixed.
We're deduplicating messages based on the id which then selects a random
message where there are duplicates. We then delete that message but the
message/receipt handle that was removed by `distinctBy` stays in the
queue until it is processed without any duplicates.

The tests won't pass until https://github.com/nationalarchives/da-aws-clients/pull/287 is merged and the dependency version is updated but otherwise this is ready.
