### PR TITLE
DR2-1924 Custodial copy errors

### DIFF
--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Main.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Main.scala
@@ -72,6 +72,7 @@ object Main extends IOApp {
       _ <- {
         Stream.fixedRateStartImmediately[IO](10.seconds) >>
           runCustodialCopy(sqs, config, processor)
+            .map(outcomes => if outcomes.exists(_.isError) then semaphore.release else IO.unit)
             .handleErrorWith(err => Stream.eval(semaphore.release >> logError(err)))
       }.compile.drain
     } yield ExitCode.Success

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/OcflServiceTest.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/OcflServiceTest.scala
@@ -312,9 +312,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
 
     commitIdCaptor.getValue should equal(id.toString)
     val capturedVersionInfo = versionInfoCaptor.getValue
-    capturedVersionInfo.getUser.getName should equal("user")
-    capturedVersionInfo.getUser.getAddress should equal("address")
-    capturedVersionInfo.getMessage should equal("message")
+    capturedVersionInfo should equal(null)
   }
 
   "commitStagedChanges" should "not commit to the repository if there are no staged changes" in {


### PR DESCRIPTION
We were getting this exception

`io.ocfl.api.exception.ObjectOutOfSyncException: Failed to update mutable HEAD of object 12f27ed2-920f-4cb0-b938-ee0a8c8cb6a1. Changes are out of sync with the current object state.\n\tat io.ocfl.core.storage.DefaultOcflStorage.createRevisionMarker(DefaultOcflStorage.java:979)\n\tat`

I'm not 100% sure of the cause.
I originally thought it was that the commit call wasn't acquiring the semaphore before committing which was causing a
race condition somewhere but adding the semaphore didn't get rid of the
error. That being said, it's probably a nice thing to have.

The other thing that it could be is that we were creating a new
VersionInfo object and passing that in. That does have an effect on the
mutable head version I think which is probably what was causing us
problems. I've passed in null instead and the error seems to have gone.

The most serious problem was that if there was an error inside the
processor as there was here, the semaphore wasn't being released so the
process would just hang.

I've added a condition that releases the semaphore if there are any
errors in any of the fibers. I can't really add a test for it without
some hefty refactoring but I've tried it on uat and it works.

----------------------------------------------------------------------------------
Edit, we're still getting the errors but less frequently so I'm going to leave this change in.
