### PR TITLE
Use ubuntu 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ permissions:
   contents: write
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Configure AWS credentials from management account

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -5,7 +5,7 @@ on:
       - closed
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.base_ref == 'main' && github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'Version bump') }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ on:
 run-name: Deploying Custodial Copy ${{inputs.to-deploy}} to ${{inputs.environment}}
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: ${{ github.event.inputs.environment }}
     steps:
       - name: Checkout


### PR DESCRIPTION
The latest release has removed a lot of tools, one of which is sbt. This
is a temporary solution while we think of a clean way of installing sbt
on every build.
