### PR TITLE
DR2-2070 Exclude embedded files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Once all messages are processed, we commit the changes to that OCFL object which
 * Get the metadata from the Preservica API
 * Create the destination path for this metadata file `{IO_REF}/{REP_TYPE}/{CO_REF}/{FILE_NAME}`
 * Use metadata information to create a `MetadataObject`
+* If the CO is an embedded file, this cannot be downloaded from Preservica. In this case, the url bitstream content url in the metadata will be empty, and we skip the final two steps. 
 * Create the destination path for the CO file `{IO_REF}/{REP_TYPE}/{CO_REF}/{GEN_TYPE}/g{GEN_VERSION}/{FILE_NAME}`
 * Use the path and bitstream information to create a `FileObject`
 

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/CustodialCopyObject.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/CustodialCopyObject.scala
@@ -13,7 +13,7 @@ sealed trait CustodialCopyObject {
   def checksums: List[Checksum]
   def name: String
   def sourceFilePath(workDir: String): IO[Path] = createDirectory(workDir).map(dir => Path(s"$dir/$name"))
-  def tableItemIdentifier: String | UUID
+  def tableItemIdentifier: String
   private def createDirectory(workDir: String): IO[Path] = {
     val path = Path(s"$workDir/downloads/${UUID.randomUUID()}/$id")
     Files[IO].createDirectories(path).map(_ => path)
@@ -26,7 +26,7 @@ object CustodialCopyObject {
       checksums: List[Checksum],
       url: String,
       destinationFilePath: String,
-      tableItemIdentifier: String | UUID
+      tableItemIdentifier: String
   ) extends CustodialCopyObject
   case class MetadataObject(
       id: UUID,
@@ -36,7 +36,7 @@ object CustodialCopyObject {
       checksums: List[Checksum],
       metadata: Elem,
       destinationFilePath: String,
-      tableItemIdentifier: String | UUID
+      tableItemIdentifier: String
   ) extends CustodialCopyObject
 }
 

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/CustodialCopyObject.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/CustodialCopyObject.scala
@@ -24,7 +24,7 @@ object CustodialCopyObject {
       checksums: List[Checksum],
       url: String,
       destinationFilePath: String,
-      tableItemIdentifier: UUID
+      tableItemIdentifier: String | UUID
   ) extends CustodialCopyObject
   case class MetadataObject(
       id: UUID,

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Main.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Main.scala
@@ -54,7 +54,7 @@ object Main extends IOApp {
       }
     }
 
-  case class IdWithSourceAndDestPaths(id: UUID, sourceNioFilePath: file.Path, destinationPath: String)
+  case class IdWithSourceAndDestPaths(id: UUID, sourceNioFilePath: Option[file.Path], destinationPath: String)
 
   override def run(args: List[String]): IO[ExitCode] =
     for {

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Message.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Message.scala
@@ -14,5 +14,5 @@ object Message {
   case class CoReceivedSnsMessage(ref: UUID, deleted: Boolean) extends ReceivedSnsMessage
   case class SoReceivedSnsMessage(ref: UUID, deleted: Boolean) extends ReceivedSnsMessage
 
-  case class SendSnsMessage(entityType: EntityType, ioRef: UUID, objectType: ObjectType, status: ObjectStatus, tableItemIdentifier: String | UUID)
+  case class SendSnsMessage(entityType: EntityType, ioRef: UUID, objectType: ObjectType, status: ObjectStatus, tableItemIdentifier: String)
 }

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/OcflService.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/OcflService.scala
@@ -37,14 +37,14 @@ class OcflService(ocflRepository: MutableOcflRepository, semaphore: Semaphore[IO
 
   def createObjects(paths: List[IdWithSourceAndDestPaths]): IO[Unit] = paths
     .traverse { path =>
-      IO.whenA(path.sourceNioFilePath.toFile.exists()) {
+      IO.whenA(path.sourceNioFilePath.isDefined) {
         semaphore.acquire >> IO.blocking {
           ocflRepository.stageChanges(
             path.id.toHeadVersion,
             null,
             { (updater: OcflObjectUpdater) =>
               updater.addPath(
-                path.sourceNioFilePath,
+                path.sourceNioFilePath.get,
                 path.destinationPath,
                 OcflOption.MOVE_SOURCE,
                 OcflOption.OVERWRITE

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
@@ -326,7 +326,7 @@ class Processor(
       _ <- logger.info(s"${missingObjectsPaths.length} objects created")
       _ <- ocflService.createObjects(changedObjectsPaths)
       _ <- logger.info(s"${changedObjectsPaths.length} objects updated")
-      
+
       _ <- missingObjectsPaths.flatMap(_.sourceNioFilePath).parTraverse(missingObjectPath => Files[IO].deleteIfExists(Path.fromNioPath(missingObjectPath)))
       _ <- changedObjectsPaths.flatMap(_.sourceNioFilePath).parTraverse(changedObjectPath => Files[IO].deleteIfExists(Path.fromNioPath(changedObjectPath)))
 

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/MainTest.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/MainTest.scala
@@ -50,6 +50,8 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
       processor: Processor
   ): List[Result] = Main.runCustodialCopy(sqsClient, config, processor).compile.toList.unsafeRunSync().flatten
 
+  private val exampleUrl = "https://example.com"
+
   "runCustodialCopy" should "(given an IO message with 'deleted' set to 'true') delete all objects underneath it" in {
     val fixity = List(Fixity("SHA256", ""))
     val ioId = UUID.randomUUID()
@@ -464,7 +466,7 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
           BitStreamInfo(
             "90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt",
             1,
-            "",
+            exampleUrl,
             List(Fixity("SHA256", "DifferentContent")),
             1,
             Original,
@@ -490,15 +492,48 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
       coContent must equal(s"File content for 90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt")
     }
 
+  "runCustodialCopy" should "not write a new version and a bitstream to a file if the CO bitstream has no url" in {
+    val fileContent = "Test"
+    val ioId = UUID.randomUUID()
+
+    val utils = new MainTestUtils(
+      List((ContentObject, false)),
+      0,
+      bitstreamInfo1Responses = List(
+        BitStreamInfo(
+          "90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt",
+          1,
+          "",
+          List(Fixity("SHA256", "DifferentContent")),
+          1,
+          Original,
+          None,
+          Some(ioId)
+        )
+      )
+    )
+
+    val repo = utils.repo
+    val expectedCoFileDestinationFilePath = utils.expectedCoFileDestinationPath
+
+    runCustodialCopy(utils.sqsClient, utils.config, utils.processor)
+
+    utils.latestObjectVersion(repo, ioId) must equal(2)
+    repo.containsObject(ioId.toString) must be(true)
+    repo.getObject(ioId.toHeadVersion).containsFile(expectedCoFileDestinationFilePath) must be(false)
+
+    repo.getObject(ioId.toHeadVersion).getFile(expectedCoFileDestinationFilePath) must equal(null)
+  }
+
   "runCustodialCopy" should "write multiple bitstreams to the same version and to the correct location" in {
     val ioId = UUID.randomUUID()
     val fixity = List(Fixity("SHA256", ""))
     val bitStreamInfoList = Seq(
-      BitStreamInfo("90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt", 1, "", fixity, 1, Original, None, Some(ioId)),
-      BitStreamInfo("90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt2", 1, "", fixity, 2, Derived, None, Some(ioId))
+      BitStreamInfo("90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt", 1, exampleUrl, fixity, 1, Original, None, Some(ioId)),
+      BitStreamInfo("90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt2", 1, exampleUrl, fixity, 2, Derived, None, Some(ioId))
     )
     val bitStreamInfoList2 = Seq(
-      BitStreamInfo("90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt3", 1, "", fixity, 1, Original, None, Some(ioId))
+      BitStreamInfo("90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt3", 1, exampleUrl, fixity, 1, Original, None, Some(ioId))
     )
 
     val utils = new MainTestUtils(

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/OcflServiceTest.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/OcflServiceTest.scala
@@ -64,7 +64,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
 
     val service = new OcflService(ocflRepository, semaphore)
     val fileObjectThatShouldBeMissing =
-      FileObject(id, name, checksums, url, destinationPath, UUID.randomUUID)
+      FileObject(id, name, checksums, url, destinationPath, UUID.randomUUID.toString)
 
     val missingAndChangedObjects =
       service.getMissingAndChangedObjects(List(fileObjectThatShouldBeMissing)).unsafeRunSync()
@@ -84,7 +84,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
 
       val service = new OcflService(ocflRepository, semaphore)
       val fileObjectThatShouldBeMissing =
-        FileObject(id, name, checksums, url, "nonExistingDestinationPath", UUID.randomUUID)
+        FileObject(id, name, checksums, url, "nonExistingDestinationPath", UUID.randomUUID.toString)
 
       val missingAndChangedObjects =
         service.getMissingAndChangedObjects(List(fileObjectThatShouldBeMissing)).unsafeRunSync()
@@ -107,7 +107,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
       val missingAndChangedObjects =
         service
           .getMissingAndChangedObjects(
-            List(FileObject(id, name, checksums, url, destinationPath, UUID.randomUUID))
+            List(FileObject(id, name, checksums, url, destinationPath, UUID.randomUUID.toString))
           )
           .unsafeRunSync()
 
@@ -123,7 +123,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
 
       val service = new OcflService(ocflRepository, semaphore)
       val fileObjectThatShouldHaveChangedChecksum =
-        FileObject(id, name, List(Checksum("SHA256", "anotherChecksum")), url, destinationPath, UUID.randomUUID)
+        FileObject(id, name, List(Checksum("SHA256", "anotherChecksum")), url, destinationPath, UUID.randomUUID.toString)
 
       val missingAndChangedObjects =
         service.getMissingAndChangedObjects(List(fileObjectThatShouldHaveChangedChecksum)).unsafeRunSync()
@@ -141,7 +141,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
 
     val service = new OcflService(ocflRepository, semaphore)
     val fileObjectThatShouldHaveChangedChecksum =
-      FileObject(id, name, checksums, url, destinationPath, UUID.randomUUID)
+      FileObject(id, name, checksums, url, destinationPath, UUID.randomUUID.toString)
 
     val ex = intercept[Exception] {
       service.getMissingAndChangedObjects(List(fileObjectThatShouldHaveChangedChecksum)).unsafeRunSync()
@@ -161,7 +161,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
 
     val service = new OcflService(ocflRepository, semaphore)
     val fileObjectThatShouldHaveChangedChecksum =
-      FileObject(id, name, checksums, url, destinationPath, UUID.randomUUID)
+      FileObject(id, name, checksums, url, destinationPath, UUID.randomUUID.toString)
 
     val ex = intercept[Exception] {
       service.getMissingAndChangedObjects(List(fileObjectThatShouldHaveChangedChecksum)).unsafeRunSync()

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/OcflServiceTest.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/OcflServiceTest.scala
@@ -177,7 +177,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
     val ocflRepository = mock[MutableOcflRepository]
     val service = new OcflService(ocflRepository, semaphore)
 
-    service.createObjects(List(IdWithSourceAndDestPaths(UUID.randomUUID, Path.of("not-exist"), "destination"))).unsafeRunSync()
+    service.createObjects(List(IdWithSourceAndDestPaths(UUID.randomUUID, None, "destination"))).unsafeRunSync()
 
     verifyNoInteractions(ocflRepository)
   }
@@ -202,7 +202,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
       }
     val service = new OcflService(ocflRepository, semaphore)
 
-    service.createObjects(List(IdWithSourceAndDestPaths(id, inputPath, destinationPath))).unsafeRunSync()
+    service.createObjects(List(IdWithSourceAndDestPaths(id, Option(inputPath), destinationPath))).unsafeRunSync()
 
     UUID.fromString(objectVersionCaptor.getValue.getObjectId) should equal(id)
     verify(updater, times(1)).addPath(

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/ProcessorTest.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/ProcessorTest.scala
@@ -104,7 +104,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
     utils.processMessage.unsafeRunSync()
 
     val bitstreamCalls = 1
-    val tableItemIdentifier = UUID.fromString("90dfb573-7419-4e89-8558-6cfa29f8fb16")
+    val tableItemIdentifier = "90dfb573-7419-4e89-8558-6cfa29f8fb16"
     utils.verifyCallsAndArguments(
       bitstreamCalls,
       1,
@@ -219,7 +219,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
     utils.processMessage.unsafeRunSync()
 
     val bitstreamCalls = 1
-    val tableItemIdentifier = UUID.fromString("90dfb573-7419-4e89-8558-6cfa29f8fb16")
+    val tableItemIdentifier = "90dfb573-7419-4e89-8558-6cfa29f8fb16"
     utils.verifyCallsAndArguments(
       bitstreamCalls,
       1,

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/ProcessorTest.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/ProcessorTest.scala
@@ -1,5 +1,6 @@
 package uk.gov.nationalarchives.custodialcopy
 
+import cats.syntax.all.*
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import fs2.io.file.Path
@@ -89,7 +90,8 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
     utils.verifyCallsAndArguments(
       repTypes = Nil,
       repIndexes = Nil,
-      createdIdSourceAndDestinationPathAndId = List(Nil, List(IdWithSourceAndDestPaths(id, Path(s"$id/IO_Metadata_changed.xml").toNioPath, "destinationPath"))),
+      createdIdSourceAndDestinationPathAndId =
+        List(Nil, List(IdWithSourceAndDestPaths(id, Path(s"$id/IO_Metadata_changed.xml").toNioPath.some, "destinationPath"))),
       snsMessagesToSend = List(SendSnsMessage(InformationObject, id, Metadata, Updated, "SourceIDValue"))
     )
   }
@@ -112,8 +114,8 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
       xmlRequestsToValidate = List(utils.coXmlToValidate),
       numOfStreamBitstreamContentCalls = bitstreamCalls,
       createdIdSourceAndDestinationPathAndId = List(
-        List(IdWithSourceAndDestPaths(id, Path(s"$id/missing").toNioPath, "destinationPath")),
-        List(IdWithSourceAndDestPaths(id, Path(s"$id/CO_Metadata_missing.xml").toNioPath, "destinationPath"))
+        List(IdWithSourceAndDestPaths(id, Path(s"$id/missing").toNioPath.some, "destinationPath")),
+        List(IdWithSourceAndDestPaths(id, Path(s"$id/CO_Metadata_missing.xml").toNioPath.some, "destinationPath"))
       ),
       drosToLookup = List(
         List(
@@ -197,11 +199,11 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
         List(
           IdWithSourceAndDestPaths(
             parentRef,
-            Path(s"$parentRef/90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt").toNioPath,
+            Path(s"$parentRef/90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt").toNioPath.some,
             s"${utils.ioId}/Preservation_1/$id/original/g1/90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt"
           ),
-          IdWithSourceAndDestPaths(parentRef, Path(s"$parentRef/CO_Metadata.xml").toNioPath, s"${utils.ioId}/Preservation_1/$id/CO_Metadata.xml"),
-          IdWithSourceAndDestPaths(parentRef, Path(s"$parentRef/IO_Metadata_missing.xml").toNioPath, "destinationPath")
+          IdWithSourceAndDestPaths(parentRef, Path(s"$parentRef/CO_Metadata.xml").toNioPath.some, s"${utils.ioId}/Preservation_1/$id/CO_Metadata.xml"),
+          IdWithSourceAndDestPaths(parentRef, Path(s"$parentRef/IO_Metadata_missing.xml").toNioPath.some, "destinationPath")
         ),
         Nil
       ),
@@ -227,8 +229,8 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
       xmlRequestsToValidate = List(utils.coXmlToValidate),
       numOfStreamBitstreamContentCalls = bitstreamCalls,
       createdIdSourceAndDestinationPathAndId = List(
-        List(IdWithSourceAndDestPaths(id, Path(s"$id/missing").toNioPath, "destinationPath")),
-        List(IdWithSourceAndDestPaths(id, Path(s"$id/CO_Metadata_missing.xml").toNioPath, "destinationPath"))
+        List(IdWithSourceAndDestPaths(id, Path(s"$id/missing").toNioPath.some, "destinationPath")),
+        List(IdWithSourceAndDestPaths(id, Path(s"$id/CO_Metadata_missing.xml").toNioPath.some, "destinationPath"))
       ),
       drosToLookup = List(
         List(
@@ -265,7 +267,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
       createdIdSourceAndDestinationPathAndId = List(
         List(), // 1st call to 'createObjects' with missingObjectsPaths arg
         List(
-          IdWithSourceAndDestPaths(id, Path(s"$id/IO_Metadata_changed.xml").toNioPath, "destinationPath")
+          IdWithSourceAndDestPaths(id, Path(s"$id/IO_Metadata_changed.xml").toNioPath.some, "destinationPath")
         ) // 2nd call to 'createObjects' with changedObjectsPaths arg
       ),
       snsMessagesToSend = List(
@@ -291,11 +293,11 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
         List(
           IdWithSourceAndDestPaths(
             id,
-            Path(s"$id/90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt").toNioPath,
+            Path(s"$id/90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt").toNioPath.some,
             s"${utils.ioId}/Preservation_1/${utils.coId}/original/g1/90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt"
           ),
-          IdWithSourceAndDestPaths(id, Path(s"$id/CO_Metadata.xml").toNioPath, s"${utils.ioId}/Preservation_1/${utils.coId}/CO_Metadata.xml"),
-          IdWithSourceAndDestPaths(id, Path(s"$id/IO_Metadata_missing.xml").toNioPath, "destinationPath")
+          IdWithSourceAndDestPaths(id, Path(s"$id/CO_Metadata.xml").toNioPath.some, s"${utils.ioId}/Preservation_1/${utils.coId}/CO_Metadata.xml"),
+          IdWithSourceAndDestPaths(id, Path(s"$id/IO_Metadata_missing.xml").toNioPath.some, "destinationPath")
         ),
         List()
       ),
@@ -324,7 +326,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
       xmlRequestsToValidate = List(utils.ioXmlToValidate),
       createdIdSourceAndDestinationPathAndId = List(
         Nil,
-        List(IdWithSourceAndDestPaths(changedFileId, Path(s"$changedFileId/IO_Metadata_changed.xml").toNioPath, "destinationPath"))
+        List(IdWithSourceAndDestPaths(changedFileId, Path(s"$changedFileId/IO_Metadata_changed.xml").toNioPath.some, "destinationPath"))
       ),
       drosToLookup = List(
         List(
@@ -360,15 +362,15 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar {
         List(
           IdWithSourceAndDestPaths(
             missingFileId,
-            Path(s"$missingFileId/90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt").toNioPath,
+            Path(s"$missingFileId/90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt").toNioPath.some,
             s"${utils.ioId}/Preservation_1/${utils.coId}/original/g1/90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt"
           ),
           IdWithSourceAndDestPaths(
             missingFileId,
-            Path(s"$missingFileId/CO_Metadata.xml").toNioPath,
+            Path(s"$missingFileId/CO_Metadata.xml").toNioPath.some,
             s"${utils.ioId}/Preservation_1/${utils.coId}/CO_Metadata.xml"
           ),
-          IdWithSourceAndDestPaths(missingFileId, Path(s"$missingFileId/IO_Metadata_missing.xml").toNioPath, "destinationPath")
+          IdWithSourceAndDestPaths(missingFileId, Path(s"$missingFileId/IO_Metadata_missing.xml").toNioPath.some, "destinationPath")
         ),
         Nil
       ),

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/testUtils/ExternalServicesTestUtils.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/testUtils/ExternalServicesTestUtils.scala
@@ -200,7 +200,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
     Files.write(fullSourceFilePath, bodyAsString.getBytes)
     val semaphore: Semaphore[IO] = Semaphore[IO](1).unsafeRunSync()
     new OcflService(repo, semaphore)
-      .createObjects(List(IdWithSourceAndDestPaths(id, fullSourceFilePath, destinationPath)))
+      .createObjects(List(IdWithSourceAndDestPaths(id, Option(fullSourceFilePath), destinationPath)))
       .unsafeRunSync()
   }
 
@@ -733,8 +733,8 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
       idWithSourceAndDestPathsCaptor.getAllValues.asScala.toList.flatten.zipWithIndex.foreach { case (capturedIdWithSourceAndDestPath, index) =>
         val expectedIdWithSourceAndDestPath = expectedIdsWithSourceAndDestPath(index)
         capturedIdWithSourceAndDestPath.id should equal(expectedIdWithSourceAndDestPath.id)
-        capturedIdWithSourceAndDestPath.sourceNioFilePath.toString
-          .endsWith(expectedIdWithSourceAndDestPath.sourceNioFilePath.toString) should equal(true)
+        capturedIdWithSourceAndDestPath.sourceNioFilePath.get.toString
+          .endsWith(expectedIdWithSourceAndDestPath.sourceNioFilePath.get.toString) should equal(true)
         capturedIdWithSourceAndDestPath.destinationPath should equal(expectedIdWithSourceAndDestPath.destinationPath)
       }
       val capturedLookupDestinationPaths = droLookupCaptor.getAllValues.asScala.toList.map(_.map(_.destinationFilePath))

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/testUtils/ExternalServicesTestUtils.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/testUtils/ExternalServicesTestUtils.scala
@@ -267,7 +267,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
         BitStreamInfo(
           "90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt",
           1,
-          "",
+          "https://example.com",
           List(Fixity("SHA256", "")),
           1,
           Original,
@@ -420,7 +420,8 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
       parentRefExists: Boolean = true,
       urlsToRepresentations: Seq[String] = Seq("http://testurl/representations/Preservation/1"),
       pathsOfObjectsUnderIo: List[String] = Nil,
-      throwErrorInMissingAndChangedObjects: Boolean = false
+      throwErrorInMissingAndChangedObjects: Boolean = false,
+      bitstreamUrl: String = "url"
   ) {
     val workDir: String = Files.createTempDirectory("download").toString
     val config: Config = Config("", "", "queueUrl", "", workDir, Option(URI.create("https://example.com")), "", "topicArn")
@@ -449,7 +450,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
     val bitstreamFromApi: BitStreamInfo = BitStreamInfo(
       "90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt",
       1,
-      "url",
+      bitstreamUrl,
       List(Fixity("sha256", "checksum")),
       genVersion,
       genType,
@@ -528,7 +529,8 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
         entityType: EntityType,
         objectHasChanged: Option[Boolean],
         pathsOfObjects: List[String] = Nil,
-        throwErrorInMissingAndChangedObjects: Boolean = false
+        throwErrorInMissingAndChangedObjects: Boolean = false,
+        bitstreamUrl: String
     ): OcflService = {
       def generateObjects(entityType: EntityType, missingOrChanged: String): List[CustodialCopyObject] = {
         val (id, consolidatedMetadata, fileObject, tableItemIdentifier) = entityType match {
@@ -542,7 +544,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
                   coId,
                   missingOrChanged,
                   List(Checksum("sha256", "checksum")),
-                  "url",
+                  bitstreamUrl,
                   "destinationPath",
                   identifier
                 )
@@ -632,7 +634,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
     when(sqsClient.deleteMessage(ArgumentMatchers.eq("queueUrl"), ArgumentMatchers.startsWith("receiptHandle")))
       .thenReturn(IO.pure(DeleteMessageResponse.builder.build))
 
-    val ocflService: OcflService = mockOcflService(entityType, objectHasChanged, pathsOfObjectsUnderIo, throwErrorInMissingAndChangedObjects)
+    val ocflService: OcflService = mockOcflService(entityType, objectHasChanged, pathsOfObjectsUnderIo, throwErrorInMissingAndChangedObjects, bitstreamUrl)
     val xmlValidator: ValidateXmlAgainstXsd[IO] = spy(ValidateXmlAgainstXsd[IO](XipXsdSchemaV7))
 
     val processor: Processor = new Processor(config, sqsClient, ocflService, entityClient, xmlValidator, snsClient)

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/testUtils/ExternalServicesTestUtils.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/testUtils/ExternalServicesTestUtils.scala
@@ -535,7 +535,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
       def generateObjects(entityType: EntityType, missingOrChanged: String): List[CustodialCopyObject] = {
         val (id, consolidatedMetadata, fileObject, tableItemIdentifier) = entityType match {
           case ContentObject =>
-            val identifier = UUID.fromString("90dfb573-7419-4e89-8558-6cfa29f8fb16")
+            val identifier = "90dfb573-7419-4e89-8558-6cfa29f8fb16"
             (
               coId,
               coConsolidatedMetadata,


### PR DESCRIPTION
Preservica will now not return a download url in the metadata if there
is no bitstream. So we check if there is a url. If there isn't, we don't
download the file. If there's no file, we don't try to stage it.

I've updated the tests and added a couple of new ones.
