### PR TITLE
DR2-2127 Logging for CC

### DIFF
--- a/custodial-copy-backend/src/main/resources/log4j2.properties
+++ b/custodial-copy-backend/src/main/resources/log4j2.properties
@@ -2,6 +2,8 @@ status = warn
 
 name = DR2LambdaLogConfiguration
 
+monitorInterval = 300
+
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = JsonTemplateLayout

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Main.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Main.scala
@@ -129,7 +129,7 @@ object Main extends IOApp {
           responses
             .filter(_.message.ref == ref)
             .map(_.receiptHandle)
-            .parTraverse(processor.deleteMessage)
+            .parTraverse(receiptHandle => logger.info(s"Deleting message with receipt handle $receiptHandle") >> processor.deleteMessage(receiptHandle))
       }
     } yield results
   }

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
@@ -296,6 +296,8 @@ class Processor(
       logger <- Slf4jLogger.create[IO]
       custodialCopyObjects <- toCustodialCopyObject(messageResponse.message)
 
+      _ <- custodialCopyObjects.traverse(obj => logger.info(Map("sourceId" -> obj.tableItemIdentifier))(s"Processing object ${obj.id}"))
+
       missingAndChangedObjects <- ocflService.getMissingAndChangedObjects(custodialCopyObjects)
       (missingIoObjects, missingCoObjects) = missingAndChangedObjects.missingObjects.partition {
         case mo: MetadataObject => mo.entityType == InformationObject


### PR DESCRIPTION
This logs the source ID in the json object for each message so we can
search for it.

It also logs the receipt handle when we delete the messages.

I've changed the docker image so that the log4j2.properties is now on
the docker container instead of inside the jar. This means that we can
mount a directory on the host to the container directory and change the
logging level if we need to, for example, setting the preservica client
to debug level.
