### PR TITLE
Stop streaming DB rows.

### DIFF
--- a/custodial-copy-re-indexer/src/main/scala/uk/gov/nationalarchives/reindexer/Database.scala
+++ b/custodial-copy-re-indexer/src/main/scala/uk/gov/nationalarchives/reindexer/Database.scala
@@ -30,11 +30,12 @@ object Database:
       logHandler = Option(LogHandler.jdkLogHandler)
     )
 
-    override def getIds: Stream[F, UUID] =
+    override def getIds: Stream[F, UUID] = Stream.evals {
       sql"select id from files group by 1"
         .query[UUID]
-        .stream
+        .to[List]
         .transact(xa)
+    }
 
     given Write[ReIndexUpdate] = Write[(String, UUID)].contramap(field => (field.value, field.id))
 


### PR DESCRIPTION
Doobie seems to be keeping the transaction open while it is streaming
the rows which means we cannot write to the sqlite database.

This now gets all of the rows in memory and streams them. This closes
the transaction.
