### PR TITLE
Update to use assetId.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,6 +120,7 @@ lazy val confirmer = (project in file("custodial-copy-confirmer"))
     scalacOptions += "-Wunused:imports",
     assembly / assemblyJarName := "custodial-copy-confirmer.jar",
     libraryDependencies ++= Seq(
+      preservicaClient,
       fs2Core,
       dynamoClient
     )

--- a/custodial-copy-confirmer/src/main/resources/application.conf
+++ b/custodial-copy-confirmer/src/main/resources/application.conf
@@ -4,3 +4,5 @@ proxy-url=${?HTTPS_PROXY}
 sqs-url=${SQS_QUEUE_URL}
 dynamo-table-name=${DYNAMO_TABLE_NAME}
 dynamo-attribute-name=${DYNAMO_ATTRIBUTE_NAME}
+preservica-url=${PRESERVICA_URL}
+preservica-secret-name=${PRESERVICA_SECRET_NAME}

--- a/custodial-copy-confirmer/src/test/resources/log4j2.properties
+++ b/custodial-copy-confirmer/src/test/resources/log4j2.properties
@@ -1,0 +1,13 @@
+status = warn
+
+name = DR2LambdaLogConfiguration
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = JsonTemplateLayout
+appender.console.layout.eventTemplateUri = classpath:EcsLayout.json
+
+## Root Logger Configuration
+rootLogger.level = info
+rootLogger.appenderRef.stdout.ref = STDOUT
+rootLogger.appenderRef.file.ref = FILE

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/MainTest.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/MainTest.scala
@@ -10,31 +10,36 @@ import java.util.UUID
 
 class MainTest extends AnyFlatSpec {
 
-  "runConfirmer" should "write to dynamo and delete the messages from the queue only if the object exists" in {
+  "runConfirmer" should "write to dynamo with the source id and delete the messages from the queue only if the object exists" in {
     val existingRef = UUID.randomUUID
+    val existingSourceId = UUID.randomUUID
     val nonExistingRef = UUID.randomUUID
+    val nonExistingSourceId = UUID.randomUUID()
+    val assetIdToEntityIds = Map(existingSourceId -> List(existingRef), nonExistingSourceId -> List(nonExistingRef))
     val inputMessages = List(
-      Message(existingRef, "batchId1"),
-      Message(nonExistingRef, "batchId2")
+      Message(existingSourceId, "batchId1"),
+      Message(nonExistingSourceId, "batchId2")
     ).map(message => MessageResponse(message.batchId, None, message))
-    val (deletedMessages, dynamoUpdateItems) = runConfirmer(inputMessages, List(existingRef), Errors())
+    val (deletedMessages, dynamoUpdateItems) = runConfirmer(inputMessages, List(existingRef), assetIdToEntityIds, Errors())
 
     deletedMessages.size should equal(1)
     deletedMessages.sorted should equal(List("batchId1"))
     dynamoUpdateItems.size should equal(1)
 
     val updateItem = dynamoUpdateItems.head
-    updateItem.primaryKeyAndItsValue("ioRef").s() should equal(existingRef.toString)
+    updateItem.primaryKeyAndItsValue("assetId").s() should equal(existingSourceId.toString)
     updateItem.primaryKeyAndItsValue("batchId").s() should equal("batchId1")
     updateItem.attributeNamesAndValuesToUpdate("attribute").get.s() should equal("true")
   }
 
   "runConfirmer" should "not delete the messages from the queue if there is an error" in {
     val existingRef = UUID.randomUUID()
+    val existingAssetId = UUID.randomUUID()
+    val assetIdToEntityIds = Map(existingAssetId -> List(existingRef))
     val inputMessages = List(MessageResponse("batchId", None, Message(existingRef, "batchId1")))
-    val (messagesInQueueOne, _) = runConfirmer(inputMessages, List(existingRef), Errors(dynamoUpdateError = true))
-    val (messagesInQueueTwo, _) = runConfirmer(inputMessages, List(existingRef), Errors(sqsReceiveError = true))
-    val (messagesInQueueThree, _) = runConfirmer(inputMessages, List(existingRef), Errors(sqsDeleteError = true))
+    val (messagesInQueueOne, _) = runConfirmer(inputMessages, List(existingRef), assetIdToEntityIds, Errors(dynamoUpdateError = true))
+    val (messagesInQueueTwo, _) = runConfirmer(inputMessages, List(existingRef), assetIdToEntityIds, Errors(sqsReceiveError = true))
+    val (messagesInQueueThree, _) = runConfirmer(inputMessages, List(existingRef), assetIdToEntityIds, Errors(sqsDeleteError = true))
 
     messagesInQueueOne.size should equal(0)
     messagesInQueueTwo.size should equal(0)
@@ -43,9 +48,33 @@ class MainTest extends AnyFlatSpec {
 
   "runConfirmer" should "process up to 50 messages if more are available" in {
     val existingRef = UUID.randomUUID()
-    val inputMessages = List(MessageResponse("batchId", None, Message(existingRef, "batchId1")))
-    val (_, dynamoUpdates) = runConfirmer(inputMessages, List(existingRef), Errors(), true)
+    val existingAssetId = UUID.randomUUID()
+    val assetIdToEntityIds = Map(existingAssetId -> List(existingRef))
+    val inputMessages = List(MessageResponse("batchId", None, Message(existingAssetId, "batchId1")))
+    val (_, dynamoUpdates) = runConfirmer(inputMessages, List(existingRef), assetIdToEntityIds, Errors(), true)
 
     dynamoUpdates.size should equal(50)
+  }
+
+  "runConfirmer" should "not write to Dynamo or delete messages if an entity cannot be found with the source id" in {
+    val existingRef = UUID.randomUUID()
+    val existingAssetId = UUID.randomUUID()
+    val assetIdToEntityIds = Map(existingAssetId -> Nil)
+    val inputMessages = List(MessageResponse("batchId", None, Message(existingAssetId, "batchId1")))
+    val (deletedMessages, dynamoUpdates) = runConfirmer(inputMessages, List(existingRef), assetIdToEntityIds, Errors())
+
+    deletedMessages.size should equal(0)
+    dynamoUpdates.size should equal(0)
+  }
+
+  "runConfirmer" should "not write to Dynamo or delete messages if more than one entity is found with the source id" in {
+    val existingRef = UUID.randomUUID()
+    val existingAssetId = UUID.randomUUID()
+    val assetIdToEntityIds = Map(existingAssetId -> List(existingAssetId, UUID.randomUUID()))
+    val inputMessages = List(MessageResponse("batchId", None, Message(existingAssetId, "batchId1")))
+    val (deletedMessages, dynamoUpdates) = runConfirmer(inputMessages, List(existingRef), assetIdToEntityIds, Errors())
+
+    deletedMessages.size should equal(0)
+    dynamoUpdates.size should equal(0)
   }
 }

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/OcflTest.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/OcflTest.scala
@@ -20,7 +20,7 @@ class OcflTest extends AnyFlatSpec:
     val nonExistingRef = UUID.randomUUID
     repository.putObject(ObjectVersionId.head(existingRef.toString), Files.createTempFile(existingRef.toString, ""), new VersionInfo())
 
-    val ocfl = Ocfl(Config("table", "attribute", "", URI.create("http://localhost"), repoDir, workDir))
+    val ocfl = Ocfl(Config("table", "attribute", "", URI.create("http://localhost"), repoDir, workDir, "", ""))
     ocfl.checkObjectExists(existingRef) should equal(true)
     ocfl.checkObjectExists(nonExistingRef) should equal(false)
   }


### PR DESCRIPTION
In the post-ingest table, we need the asset ID to be in there as this is
the id we send in the messages.

But the OCFL objects are stored as the Preservica id so we need to look
up the Preservica id from the asset id (via the SourceID identifier) and
then use this to check the OCFL repo
