### PR TITLE
DR2-2430 Make deletions work in CC.

### DIFF
--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Main.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Main.scala
@@ -48,7 +48,7 @@ object Main extends IOApp {
             case "co" => CoReceivedSnsMessage(ref)
             case "so" => SoReceivedSnsMessage(ref)
           }
-        case Array(ref) => DeletedReceivedSnsMessage(UUID.fromString(ref))
+        case Array(ref) => DeletionReceivedSnsMessage(UUID.fromString(ref))
     }
 
   case class IdWithSourceAndDestPaths(id: UUID, sourceNioFilePath: Option[file.Path], destinationPath: String)

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Main.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Main.scala
@@ -40,13 +40,15 @@ object Main extends IOApp {
       deleted <- c.downField("deleted").as[Boolean]
     } yield {
       val typeAndRef = id.split(":")
-      val ref = UUID.fromString(typeAndRef.last)
-      val entityType = typeAndRef.head
-      entityType match {
-        case "io" => IoReceivedSnsMessage(ref, deleted)
-        case "co" => CoReceivedSnsMessage(ref, deleted)
-        case "so" => SoReceivedSnsMessage(ref, deleted)
-      }
+      typeAndRef match
+        case Array(entityType, refString) =>
+          val ref = UUID.fromString(refString)
+          entityType match {
+            case "io" => IoReceivedSnsMessage(ref)
+            case "co" => CoReceivedSnsMessage(ref)
+            case "so" => SoReceivedSnsMessage(ref)
+          }
+        case Array(ref) => DeletedReceivedSnsMessage(UUID.fromString(ref))
     }
 
   case class IdWithSourceAndDestPaths(id: UUID, sourceNioFilePath: Option[file.Path], destinationPath: String)

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Message.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Message.scala
@@ -12,7 +12,7 @@ object Message {
   case class IoReceivedSnsMessage(ref: UUID) extends ReceivedSnsMessage
   case class CoReceivedSnsMessage(ref: UUID) extends ReceivedSnsMessage
   case class SoReceivedSnsMessage(ref: UUID) extends ReceivedSnsMessage
-  case class DeletedReceivedSnsMessage(ref: UUID) extends ReceivedSnsMessage
+  case class DeletionReceivedSnsMessage(ref: UUID) extends ReceivedSnsMessage
 
   case class SendSnsMessage(entityType: EntityType, ioRef: UUID, objectType: ObjectType, status: ObjectStatus, tableItemIdentifier: String)
 }

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Message.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Message.scala
@@ -8,11 +8,11 @@ import uk.gov.nationalarchives.custodialcopy.Processor.ObjectType
 object Message {
   sealed trait ReceivedSnsMessage {
     val ref: UUID
-    val deleted: Boolean
   }
-  case class IoReceivedSnsMessage(ref: UUID, deleted: Boolean) extends ReceivedSnsMessage
-  case class CoReceivedSnsMessage(ref: UUID, deleted: Boolean) extends ReceivedSnsMessage
-  case class SoReceivedSnsMessage(ref: UUID, deleted: Boolean) extends ReceivedSnsMessage
+  case class IoReceivedSnsMessage(ref: UUID) extends ReceivedSnsMessage
+  case class CoReceivedSnsMessage(ref: UUID) extends ReceivedSnsMessage
+  case class SoReceivedSnsMessage(ref: UUID) extends ReceivedSnsMessage
+  case class DeletedReceivedSnsMessage(ref: UUID) extends ReceivedSnsMessage
 
   case class SendSnsMessage(entityType: EntityType, ioRef: UUID, objectType: ObjectType, status: ObjectStatus, tableItemIdentifier: String)
 }

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/OcflService.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/OcflService.scala
@@ -124,7 +124,7 @@ class OcflService(ocflRepository: MutableOcflRepository, semaphore: Semaphore[IO
     IO.blocking(ocflRepository.getObject(ioId.toHeadVersion))
       .map(_.getFiles.asScala.toList.map(_.getPath))
       .handleErrorWith {
-        case nfe: NotFoundException => IO.raiseError(new Exception(s"Object id $ioId does not exist"))
+        case nfe: NotFoundException => IO.pure(Nil)
         case coe: CorruptObjectException =>
           purgeObject(ioId) >>
             IO.raiseError(

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/OcflService.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/OcflService.scala
@@ -124,7 +124,7 @@ class OcflService(ocflRepository: MutableOcflRepository, semaphore: Semaphore[IO
     IO.blocking(ocflRepository.getObject(ioId.toHeadVersion))
       .map(_.getFiles.asScala.toList.map(_.getPath))
       .handleErrorWith {
-        case nfe: NotFoundException => IO.pure(Nil)
+        case nfe: NotFoundException => Logger[IO].warn(s"$ioId not found in the repository.") >> IO.pure(Nil)
         case coe: CorruptObjectException =>
           purgeObject(ioId) >>
             IO.raiseError(

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
@@ -16,8 +16,8 @@ import uk.gov.nationalarchives.custodialcopy.Main.{Config, IdWithSourceAndDestPa
 import uk.gov.nationalarchives.custodialcopy.Message.*
 import uk.gov.nationalarchives.custodialcopy.Processor.{ObjectStatus, Result}
 import uk.gov.nationalarchives.custodialcopy.Processor.Result.*
-import uk.gov.nationalarchives.custodialcopy.Processor.ObjectStatus.{Created, Deleted, Updated}
-import uk.gov.nationalarchives.custodialcopy.Processor.ObjectType.{Bitstream, Metadata, MetadataAndPotentialBitstreams}
+import uk.gov.nationalarchives.custodialcopy.Processor.ObjectStatus.{Created, Updated}
+import uk.gov.nationalarchives.custodialcopy.Processor.ObjectType.{Bitstream, Metadata}
 import uk.gov.nationalarchives.dp.client.{EntityClient, ValidateXmlAgainstXsd}
 import uk.gov.nationalarchives.dp.client.Client.BitStreamInfo
 import uk.gov.nationalarchives.dp.client.EntityClient.RepresentationType.*
@@ -196,9 +196,9 @@ class Processor(
     } ++ metadata
 
   private def toCustodialCopyObject(receivedSnsMessage: ReceivedSnsMessage): IO[List[CustodialCopyObject]] = receivedSnsMessage match {
-    case IoReceivedSnsMessage(ref, deleted) =>
+    case IoReceivedSnsMessage(ref) =>
       for {
-        entity <- fromType[IO](InformationObject.entityTypeShort, ref, None, None, deleted = deleted)
+        entity <- fromType[IO](InformationObject.entityTypeShort, ref, None, None, deleted = false)
         metadataFileName = createMetadataFileName(InformationObject.entityTypeShort)
         metadataObject <- entityClient.metadataForEntity(entity).flatMap { metadata =>
           val destinationFilePath = createDestinationFilePath(entity.ref, fileName = metadataFileName)
@@ -212,7 +212,7 @@ class Processor(
           )
         }
       } yield metadataObject
-    case CoReceivedSnsMessage(ref, deleted) =>
+    case CoReceivedSnsMessage(ref) =>
       for {
         bitstreamInfoPerCo <- entityClient.getBitstreamInfo(ref)
         entity <- fromType[IO](
@@ -220,7 +220,7 @@ class Processor(
           ref,
           None,
           None,
-          deleted = deleted,
+          deleted = false,
           parent = bitstreamInfoPerCo.headOption.flatMap(_.parentRef)
         )
         parentRef <- IO.fromOption(entity.parent)(new Exception("Cannot get IO reference from CO"))
@@ -229,7 +229,7 @@ class Processor(
         coFileAndMetadataObjects <- getCoFileAndMetadataObjects(entity, parentRef, coRepTypes, bitstreamInfoPerCo)
       } yield coFileAndMetadataObjects
 
-    case SoReceivedSnsMessage(_, _) => IO.pure(Nil)
+    case _ => IO.pure(Nil)
   }
 
   private def download(custodialCopyObject: CustodialCopyObject) = custodialCopyObject match {
@@ -269,18 +269,19 @@ class Processor(
       obj: CustodialCopyObject,
       receivedSnsMessage: ReceivedSnsMessage,
       status: ObjectStatus
-  ): SendSnsMessage = {
+  ): Option[SendSnsMessage] = {
     val objectType = obj match {
       case _: FileObject     => Bitstream
       case _: MetadataObject => Metadata
     }
 
-    val entityType = receivedSnsMessage match
-      case _: IoReceivedSnsMessage => InformationObject
-      case _: CoReceivedSnsMessage => ContentObject
-      case _: SoReceivedSnsMessage => StructuralObject
+    val potentialEntityType = receivedSnsMessage match
+      case _: IoReceivedSnsMessage => Option(InformationObject)
+      case _: CoReceivedSnsMessage => Option(ContentObject)
+      case _: SoReceivedSnsMessage => Option(StructuralObject)
+      case _                       => None
 
-    SendSnsMessage(entityType, obj.id, objectType, status, obj.tableItemIdentifier)
+    potentialEntityType.map(entityType => SendSnsMessage(entityType, obj.id, objectType, status, obj.tableItemIdentifier))
   }
 
   given Encoder[SendSnsMessage] = (message: SendSnsMessage) => {
@@ -332,39 +333,25 @@ class Processor(
       _ <- missingObjectsPaths.flatMap(_.sourceNioFilePath).parTraverse(missingObjectPath => Files[IO].deleteIfExists(Path.fromNioPath(missingObjectPath)))
       _ <- changedObjectsPaths.flatMap(_.sourceNioFilePath).parTraverse(changedObjectPath => Files[IO].deleteIfExists(Path.fromNioPath(changedObjectPath)))
 
-      createdObjsSnsMessages = missingAndChangedObjects.missingObjects.map(generateSnsMessage(_, messageResponse.message, Created))
-      updatedObjsSnsMessages = missingAndChangedObjects.changedObjects.map(generateSnsMessage(_, messageResponse.message, Updated))
+      createdObjsSnsMessages = missingAndChangedObjects.missingObjects.flatMap(generateSnsMessage(_, messageResponse.message, Created))
+      updatedObjsSnsMessages = missingAndChangedObjects.changedObjects.flatMap(generateSnsMessage(_, messageResponse.message, Updated))
 
     } yield createdObjsSnsMessages ++ updatedObjsSnsMessages
 
   private def processDeletedEntities(messageResponse: MessageResponse[ReceivedSnsMessage]): IO[List[SendSnsMessage]] =
-    messageResponse.message match {
-      case IoReceivedSnsMessage(ref, _) =>
-        for {
-          filePaths <- ocflService.getAllFilePathsOnAnObject(ref)
-          _ <- ocflService.deleteObjects(ref, filePaths)
-          deletedObjsSnsMessages = List(SendSnsMessage(InformationObject, ref, MetadataAndPotentialBitstreams, Deleted, ""))
-        } yield deletedObjsSnsMessages
-      case CoReceivedSnsMessage(ref, _) =>
-        IO.raiseError(new Exception(s"A Content Object '$ref' has been deleted in Preservica"))
-      case _ =>
-        IO.raiseError(new Exception(s"Entity type is not supported for deletion"))
-    }
-
-  private def deletionSupported(messageResponse: MessageResponse[ReceivedSnsMessage]): IO[Boolean] = IO.pure {
-    messageResponse.message match {
-      case SoReceivedSnsMessage(_, _) => false
-      case _                          => true
-    }
-  }
+    val ref = messageResponse.message.ref
+    for {
+      filePaths <- ocflService.getAllFilePathsOnAnObject(ref)
+      _ <- ocflService.deleteObjects(ref, filePaths)
+    } yield Nil
 
   def process(messageResponse: MessageResponse[ReceivedSnsMessage]): IO[Result] = {
     for {
       logger <- Slf4jLogger.create[IO]
-      entityTypeDeletionSupported <- deletionSupported(messageResponse)
       snsMessages <-
-        if messageResponse.message.deleted && entityTypeDeletionSupported then processDeletedEntities(messageResponse)
-        else processNonDeletedMessages(messageResponse)
+        messageResponse.message match
+          case DeletedReceivedSnsMessage(ref) => processDeletedEntities(messageResponse)
+          case _                              => processNonDeletedMessages(messageResponse)
       _ <- IO.whenA(snsMessages.nonEmpty) {
         snsClient.publish[SendSnsMessage](config.topicArn)(snsMessages).void
       }

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
@@ -350,8 +350,8 @@ class Processor(
       logger <- Slf4jLogger.create[IO]
       snsMessages <-
         messageResponse.message match
-          case DeletedReceivedSnsMessage(ref) => processDeletedEntities(messageResponse)
-          case _                              => processNonDeletedMessages(messageResponse)
+          case DeletionReceivedSnsMessage(ref) => processDeletedEntities(messageResponse)
+          case _                               => processNonDeletedMessages(messageResponse)
       _ <- IO.whenA(snsMessages.nonEmpty) {
         snsClient.publish[SendSnsMessage](config.topicArn)(snsMessages).void
       }
@@ -373,7 +373,7 @@ object Processor {
   )
 
   enum ObjectStatus:
-    case Created, Updated, Deleted
+    case Created, Updated
 
   enum ObjectType:
     case Bitstream, Metadata, MetadataAndPotentialBitstreams

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/MainTest.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/MainTest.scala
@@ -308,58 +308,6 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
     verify(processor, never()).process(any[MessageResponse[ReceivedSnsMessage]])
   }
 
-  "runCustodialCopy" should "(given a CO message with 'deleted' set to 'true') throw an Exception" in {
-    val fixity = Fixity("SHA256", "")
-
-    val utils = new MainTestUtils(
-      List((ContentObject, true)),
-      typesOfMetadataFilesInRepo = List(InformationObject, ContentObject),
-      objectVersion = 2,
-      fileContentToWriteToEachFileInRepo = List("fileContent1"),
-      entityDeleted = true
-    )
-
-    val repo = utils.repo
-
-    utils.latestObjectVersion(repo, utils.ioId) must equal(2)
-
-    val err: Throwable = getError(utils.sqsClient, utils.config, utils.processor)
-
-    err.getMessage must equal(s"A Content Object '${utils.coId1}' has been deleted in Preservica")
-  }
-
-  "runCustodialCopy" should "(given a CO and IO message that both have 'deleted' set to 'true') the exception message thrown by the CO message " +
-    "doesn't prevent the IO message from being processed" in {
-      val fixity = Fixity("SHA256", "")
-
-      val utils = new MainTestUtils(
-        List((ContentObject, true), (InformationObject, true)),
-        typesOfMetadataFilesInRepo = List(InformationObject, ContentObject),
-        objectVersion = 2,
-        fileContentToWriteToEachFileInRepo = List("fileContent1"),
-        entityDeleted = true
-      )
-
-      val repo = utils.repo
-
-      utils.latestObjectVersion(repo, utils.ioId) must equal(2)
-      val expectedDestinationFilePathsAlreadyInRepo = List(
-        s"${utils.ioId}/Preservation_1/${utils.coId1}/original/g1/90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt",
-        s"${utils.ioId}/Preservation_1/${utils.coId1}/CO_Metadata.xml",
-        s"${utils.ioId}/IO_Metadata.xml"
-      )
-
-      expectedDestinationFilePathsAlreadyInRepo.foreach { path =>
-        repo.getObject(utils.ioId.toHeadVersion).containsFile(path) must be(true)
-      }
-
-      val err: Throwable = getError(utils.sqsClient, utils.config, utils.processor)
-
-      err.getMessage must equal(s"A Content Object '${utils.coId1}' has been deleted in Preservica")
-      utils.latestObjectVersion(repo, utils.ioId) must equal(2)
-      repo.getObject(utils.ioId.toHeadVersion).getFiles.toArray.toList must be(Nil)
-    }
-
   "runCustodialCopy" should "(given a CO message that has 'deleted' set to 'false' and IO message that has 'deleted' set to 'true') " +
     "parse the non-deleted (CO) message first" in {
       val fixity = Fixity("SHA256", "")
@@ -760,7 +708,7 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
     val utils = new MainTestUtils(objectVersion = 0)
     val sqsClient = utils.sqsClient
     val groupId = UUID.randomUUID.toString
-    def messages = (1 to 10).map(i => MessageResponse("", Option(groupId), SoReceivedSnsMessage(UUID.randomUUID, false))).toList
+    def messages = (1 to 10).map(i => MessageResponse("", Option(groupId), SoReceivedSnsMessage(UUID.randomUUID))).toList
     reset(sqsClient)
     when(sqsClient.deleteMessage(any[String], any[String])).thenReturn(IO(DeleteMessageResponse.builder.build))
     when(sqsClient.receiveMessages(any[String], any[Int])(using any[Decoder[SoReceivedSnsMessage]]))
@@ -778,7 +726,7 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
     val sqsClient = utils.sqsClient
     val groupId = UUID.randomUUID.toString
 
-    def messages = (1 to 25).map(i => MessageResponse("", Option(groupId), SoReceivedSnsMessage(UUID.randomUUID, false))).toList
+    def messages = (1 to 25).map(i => MessageResponse("", Option(groupId), SoReceivedSnsMessage(UUID.randomUUID))).toList
 
     reset(sqsClient)
     when(sqsClient.deleteMessage(any[String], any[String])).thenReturn(IO(DeleteMessageResponse.builder.build))
@@ -798,7 +746,7 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
     val sqsClient = utils.sqsClient
     val groupId = UUID.randomUUID.toString
 
-    def messages = (1 to 26).map(i => MessageResponse("", Option(groupId), SoReceivedSnsMessage(UUID.randomUUID, false))).toList
+    def messages = (1 to 26).map(i => MessageResponse("", Option(groupId), SoReceivedSnsMessage(UUID.randomUUID))).toList
 
     reset(sqsClient)
     when(sqsClient.deleteMessage(any[String], any[String])).thenReturn(IO(DeleteMessageResponse.builder.build))
@@ -833,7 +781,7 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues {
     val sqsClient = utils.sqsClient
     val groupId = UUID.randomUUID.toString
 
-    def messages = (1 to 10).map(i => MessageResponse("", Option(groupId), SoReceivedSnsMessage(UUID.randomUUID, false))).toList
+    def messages = (1 to 10).map(i => MessageResponse("", Option(groupId), SoReceivedSnsMessage(UUID.randomUUID))).toList
 
     reset(sqsClient)
     when(sqsClient.deleteMessage(any[String], any[String])).thenReturn(IO(DeleteMessageResponse.builder.build))

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/OcflServiceTest.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/OcflServiceTest.scala
@@ -209,20 +209,6 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
     optionOverwriteToAdd.getAllValues.asScala.toList.head should equal(OcflOption.OVERWRITE)
   }
 
-  "getAllFilePathsOnAnObject" should "throw an exception if the object to be deleted does not exist" in {
-    val id = UUID.randomUUID()
-    val ocflRepository = mock[MutableOcflRepository]
-    when(ocflRepository.getObject(any[ObjectVersionId])).thenThrow(new NotFoundException)
-
-    val service = new OcflService(ocflRepository, semaphore)
-
-    val err = intercept[Exception] {
-      service.getAllFilePathsOnAnObject(id).unsafeRunSync()
-    }
-
-    err.getMessage should equal(s"Object id $id does not exist")
-  }
-
   "getAllFilePathsOnAnObject" should "return a path if the repository contains the OCFL object" in {
     val id = UUID.randomUUID()
     val ocflRepository = mock[MutableOcflRepository]

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/testUtils/ExternalServicesTestUtils.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/testUtils/ExternalServicesTestUtils.scala
@@ -29,7 +29,7 @@ import uk.gov.nationalarchives.custodialcopy.{Checksum, CustodialCopyObject, Mes
 import uk.gov.nationalarchives.custodialcopy.Main.{Config, IdWithSourceAndDestPaths}
 import uk.gov.nationalarchives.custodialcopy.Message.{
   CoReceivedSnsMessage,
-  DeletedReceivedSnsMessage,
+  DeletionReceivedSnsMessage,
   IoReceivedSnsMessage,
   ReceivedSnsMessage,
   SendSnsMessage,
@@ -307,12 +307,12 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
     private val sqsMessages: List[ReceivedSnsMessage] =
       typesOfSqsMsgAndDeletionStatus.zipWithIndex.flatMap { case ((entityType, hasBeenDeleted), index) =>
         entityType match { // create duplicates in order to test deduplication
-          case InformationObject => (1 to 2).map(_ => if hasBeenDeleted then DeletedReceivedSnsMessage(ioId) else IoReceivedSnsMessage(ioId))
+          case InformationObject => (1 to 2).map(_ => if hasBeenDeleted then DeletionReceivedSnsMessage(ioId) else IoReceivedSnsMessage(ioId))
           case ContentObject =>
             val coId = coIds(index)
-            (1 to 2).map(_ => if hasBeenDeleted then DeletedReceivedSnsMessage(coId) else CoReceivedSnsMessage(coId))
+            (1 to 2).map(_ => if hasBeenDeleted then DeletionReceivedSnsMessage(coId) else CoReceivedSnsMessage(coId))
           case StructuralObject =>
-            (1 to 2).map(_ => if hasBeenDeleted then DeletedReceivedSnsMessage(UUID.randomUUID) else SoReceivedSnsMessage(UUID.randomUUID))
+            (1 to 2).map(_ => if hasBeenDeleted then DeletionReceivedSnsMessage(UUID.randomUUID) else SoReceivedSnsMessage(UUID.randomUUID))
         }
       }
     val sqsClient: DASQSClient[IO] = mockSqs(sqsMessages, ioId.toString)
@@ -445,7 +445,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
     lazy val coMessage: CoReceivedSnsMessage = CoReceivedSnsMessage(coId)
     lazy val ioMessage: IoReceivedSnsMessage = IoReceivedSnsMessage(ioId)
     lazy val soMessage: SoReceivedSnsMessage = SoReceivedSnsMessage(soId)
-    lazy val deletedMessage: DeletedReceivedSnsMessage = DeletedReceivedSnsMessage(deletedId)
+    lazy val deletedMessage: DeletionReceivedSnsMessage = DeletionReceivedSnsMessage(deletedId)
     val sqsClient: DASQSClient[IO] = mock[DASQSClient[IO]]
 
     val snsClient: DASNSClient[IO] = mock[DASNSClient[IO]]

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/testUtils/ExternalServicesTestUtils.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/testUtils/ExternalServicesTestUtils.scala
@@ -27,7 +27,14 @@ import uk.gov.nationalarchives.utils.TestUtils.*
 import uk.gov.nationalarchives.custodialcopy.CustodialCopyObject.{FileObject, MetadataObject}
 import uk.gov.nationalarchives.custodialcopy.{Checksum, CustodialCopyObject, Message, OcflService, Processor}
 import uk.gov.nationalarchives.custodialcopy.Main.{Config, IdWithSourceAndDestPaths}
-import uk.gov.nationalarchives.custodialcopy.Message.{CoReceivedSnsMessage, IoReceivedSnsMessage, ReceivedSnsMessage, SendSnsMessage, SoReceivedSnsMessage}
+import uk.gov.nationalarchives.custodialcopy.Message.{
+  CoReceivedSnsMessage,
+  DeletedReceivedSnsMessage,
+  IoReceivedSnsMessage,
+  ReceivedSnsMessage,
+  SendSnsMessage,
+  SoReceivedSnsMessage
+}
 import uk.gov.nationalarchives.custodialcopy.OcflService.MissingAndChangedObjects
 import uk.gov.nationalarchives.*
 import uk.gov.nationalarchives.custodialcopy.Processor.Result
@@ -183,7 +190,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
       repo: MutableOcflRepository,
       existingMetadata: Elem,
       destinationPath: String
-  ) = {
+  ): Unit = {
     val xmlAsString = existingMetadata.toString()
     addFileToRepo(id, repo, xmlAsString, metadataFile(id, entityType), destinationPath)
   }
@@ -194,7 +201,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
       bodyAsString: String,
       sourceFilePath: String,
       destinationPath: String
-  ) = {
+  ): Unit = {
     val path = Files.createTempDirectory(id.toString)
     Files.createDirectories(Paths.get(path.toString, id.toString))
     val fullSourceFilePath = Paths.get(path.toString, sourceFilePath)
@@ -300,11 +307,12 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
     private val sqsMessages: List[ReceivedSnsMessage] =
       typesOfSqsMsgAndDeletionStatus.zipWithIndex.flatMap { case ((entityType, hasBeenDeleted), index) =>
         entityType match { // create duplicates in order to test deduplication
-          case InformationObject => (1 to 2).map(_ => IoReceivedSnsMessage(ioId, hasBeenDeleted))
+          case InformationObject => (1 to 2).map(_ => if hasBeenDeleted then DeletedReceivedSnsMessage(ioId) else IoReceivedSnsMessage(ioId))
           case ContentObject =>
             val coId = coIds(index)
-            (1 to 2).map(_ => CoReceivedSnsMessage(coId, hasBeenDeleted))
-          case StructuralObject => (1 to 2).map(_ => SoReceivedSnsMessage(UUID.randomUUID, hasBeenDeleted))
+            (1 to 2).map(_ => if hasBeenDeleted then DeletedReceivedSnsMessage(coId) else CoReceivedSnsMessage(coId))
+          case StructuralObject =>
+            (1 to 2).map(_ => if hasBeenDeleted then DeletedReceivedSnsMessage(UUID.randomUUID) else SoReceivedSnsMessage(UUID.randomUUID))
         }
       }
     val sqsClient: DASQSClient[IO] = mockSqs(sqsMessages, ioId.toString)
@@ -432,10 +440,12 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
     val ioId: UUID = UUID.randomUUID()
     val coId: UUID = UUID.randomUUID()
     val soId: UUID = UUID.randomUUID()
+    val deletedId: UUID = UUID.randomUUID()
 
-    lazy val coMessage: CoReceivedSnsMessage = CoReceivedSnsMessage(coId, false)
-    lazy val ioMessage: IoReceivedSnsMessage = IoReceivedSnsMessage(ioId, false)
-    lazy val soMessage: SoReceivedSnsMessage = SoReceivedSnsMessage(soId, false)
+    lazy val coMessage: CoReceivedSnsMessage = CoReceivedSnsMessage(coId)
+    lazy val ioMessage: IoReceivedSnsMessage = IoReceivedSnsMessage(ioId)
+    lazy val soMessage: SoReceivedSnsMessage = SoReceivedSnsMessage(soId)
+    lazy val deletedMessage: DeletedReceivedSnsMessage = DeletedReceivedSnsMessage(deletedId)
     val sqsClient: DASQSClient[IO] = mock[DASQSClient[IO]]
 
     val snsClient: DASNSClient[IO] = mock[DASNSClient[IO]]
@@ -564,7 +574,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
             id,
             entityType,
             Some("Preservation_1"),
-            s"${entityType.entityTypeShort}_Metadata_${missingOrChanged}.xml",
+            s"${entityType.entityTypeShort}_Metadata_$missingOrChanged.xml",
             List(Checksum("sha256", "checksum")),
             consolidatedMetadata,
             "destinationPath",
@@ -748,7 +758,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
       capturedLookupDestinationPaths should equal(drosToLookup)
 
       if numOfTimesToDeleteObjects > 0 then
-        ioToDeleteObjectsFromCaptor.getValue should equal(ioId)
+        ioToDeleteObjectsFromCaptor.getValue should equal(deletedId)
         pathsToDeleteCaptor.getValue should equal(destinationPathsToDelete)
 
       if (numOfTimesSnsMsgShouldBeSent > 0) {


### PR DESCRIPTION
Because we don't know the entity type of a deleted entity, the original
way of doing this does't work. So all the checks about which entity
types can be deleted have gone.
We now check to see if the id is in the OCFL repository, if it's not, we
ignore it and move on as this will be a CO or SO.
If it's a deleted entity, we don't send a message to the SNS topic for a
deleted message as this only goes to the db builder anyway.
