### PR TITLE
DR2-2459 Don't filter derived objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,28 +363,15 @@ two storage mediums to become out of sync. We are only concerned with original n
 
 ### The process
 
-1. Make a call to Preservica to stream the refs of every entity we have stored
-2. It will filter out anything that is not an IO ref nor CO ref
+1. Stream every entity from Preservica via paginated calls to the `updated-since` endpoint.
+2. It will filter out anything that is not a CO ref.
 3. Splits the remaining object refs into Chunks:
 4. Run this process for each Chunk:
-   1. if the object ref if an Information Object one, it will
-      1. get all the object files from OCFL
-      2. if the object is a CO content file
-         1. get the storage path and extract the CO ref
-         2. get the sha256 fixity of the CO
-         3. add each of these values (including the IO ref) to an `OcflCoRow` object
-   2. if the object ref is a Content Object one, it will:
-      1. get the bitstream info from Preservica
-      2. filter it out if it's a non-Original and non-Preservation CO (The opposite of "Preservation" is "Access")
-      3. retrieve the IO ref and sha256 checksum
-      4. add each of these values to an `PreservicaCoRow` object
-   3. Return these `CoRow`s in a Chunk
-5. For each `CoRow` object
-   1. gather all `PreservicaCoRow`s into a Chunk
-   2. gather all `OcflCoRow`s into a Chunk
-   3. write the Chunk of `PreservicaCoRow`s to a table
-   4. write the Chunk of `OcflCoRow`s to another table
-6. Now that they have been saved to the tables, the stream can be drained (in order to discard anything returned)
+   1. get the bitstream info from Preservica
+   2. retrieve the IO ref and sha256 checksum
+   3. Return these `CoRow`s
+5. There is a parallel process which streams all OCFL objects from the repository and writes them in chunks to the database. 
+6. Once both processes have completed and all rows have been written to the database, the stream can be drained (in order to discard anything returned)
 7. Find the missing COs in each table
    1. first parse the `PreservicaCOs` table and check if the checksum(s) appear in the `OcflCos` table
       1. if not, for each missing CO

--- a/custodial-copy-reconciler/src/main/scala/uk/gov/nationalarchives/reconciler/Main.scala
+++ b/custodial-copy-reconciler/src/main/scala/uk/gov/nationalarchives/reconciler/Main.scala
@@ -118,7 +118,7 @@ object Main extends IOApp {
       .compile
       .drain
 
-    IO.both(ocfl, ps) >> database.findAllMissingCOs().flatMap { result =>
+    database.deleteFromTables() >> IO.both(ocfl, ps) >> database.findAllMissingCOs().flatMap { result =>
       val missingCOs = result.psCOsMissingFromCc ++ result.ccCOsMissingFromPs
       logCompletion(result) >>
         IO.whenA(missingCOs.nonEmpty) {

--- a/custodial-copy-reconciler/src/main/scala/uk/gov/nationalarchives/reconciler/OcflService.scala
+++ b/custodial-copy-reconciler/src/main/scala/uk/gov/nationalarchives/reconciler/OcflService.scala
@@ -48,7 +48,7 @@ object OcflService {
       .buildMutable()
 
     def isNotMetadataFile(storageRelativePath: String) =
-      (storageRelativePath.contains("/Preservation_") || storageRelativePath.contains("/Access_")) && !storageRelativePath.contains("CO_Metadata.xml")
+      storageRelativePath.contains("/Preservation_") && !storageRelativePath.contains("CO_Metadata.xml")
 
     def filesForId(id: String) = {
       val ioRef = UUID.fromString(id)

--- a/custodial-copy-reconciler/src/main/scala/uk/gov/nationalarchives/reconciler/OcflService.scala
+++ b/custodial-copy-reconciler/src/main/scala/uk/gov/nationalarchives/reconciler/OcflService.scala
@@ -55,9 +55,7 @@ object OcflService {
       val chunk = Chunk.from(repo.getObject(ioRef.toHeadVersion).getFiles.asScala).collect {
         case coFile if isNotMetadataFile(coFile.getStorageRelativePath) =>
           val pathAsList = coFile.getStorageRelativePath.split("/")
-          val pathStartingFromRepType =
-            if coFile.getStorageRelativePath.contains("/Preservation_") then pathAsList.dropWhile(pathPart => !pathPart.startsWith("Preservation_"))
-            else pathAsList.dropWhile(pathPart => !pathPart.startsWith("Access_"))
+          val pathStartingFromRepType = pathAsList.dropWhile(pathPart => !pathPart.startsWith("Preservation_") && !pathPart.startsWith("Access_"))
           val coRef = UUID.fromString(pathStartingFromRepType(1))
           val fixities = coFile.getFixity.asScala.toMap.map { case (digestAlgo, value) => (digestAlgo.getOcflName, value) }
           val potentialSha256 = fixities.get("sha256")

--- a/custodial-copy-reconciler/src/test/scala/uk/gov/nationalarchives/reconciler/BuilderSpec.scala
+++ b/custodial-copy-reconciler/src/test/scala/uk/gov/nationalarchives/reconciler/BuilderSpec.scala
@@ -18,7 +18,7 @@ import scala.jdk.CollectionConverters.*
 
 class BuilderSpec extends AnyFlatSpec:
 
-  "Builder run" should ", given a ContentObject, return only the Preservica CoRows for COs that have the generation type of 'Original' and generation version of '1'" in {
+  "Builder run" should ", given a ContentObject, return all Preservica CoRows" in {
     val config = Config("", "", 5, Files.createTempDirectory("work").toString, Files.createTempDirectory("repo").toString)
     val potentialParentRef = Some(UUID.randomUUID)
     val co1Ref = UUID.randomUUID
@@ -35,9 +35,11 @@ class BuilderSpec extends AnyFlatSpec:
     val entityIds: Seq[UUID] = Seq(co1Ref)
 
     val preservicaCoRows = Builder[IO](preservicaClient).run(entityIds).unsafeRunSync()
-    preservicaCoRows should equal(
-      List(CoRow(co1Ref, potentialParentRef, Some("co1FileFixity")))
-    )
+
+    preservicaCoRows.length should equal(2)
+
+    preservicaCoRows.contains(CoRow(co1Ref, potentialParentRef, Some("co1FileFixity"))) should equal(true)
+    preservicaCoRows.contains(CoRow(co1Ref, potentialParentRef, Some("co1FileFixity2"))) should equal(true)
   }
 
   private def createObjectVersionFile(path: String, fixityMap: Map[DigestAlgorithm, String]) =

--- a/custodial-copy-reconciler/src/test/scala/uk/gov/nationalarchives/reconciler/BuilderSpec.scala
+++ b/custodial-copy-reconciler/src/test/scala/uk/gov/nationalarchives/reconciler/BuilderSpec.scala
@@ -18,7 +18,7 @@ import scala.jdk.CollectionConverters.*
 
 class BuilderSpec extends AnyFlatSpec:
 
-  "Builder run" should ", given a ContentObject, return all Preservica CoRows" in {
+  "Builder run" should ", given a ContentObject, return all Preservica CoRows regardless of generation type and version" in {
     val config = Config("", "", 5, Files.createTempDirectory("work").toString, Files.createTempDirectory("repo").toString)
     val potentialParentRef = Some(UUID.randomUUID)
     val co1Ref = UUID.randomUUID
@@ -32,14 +32,15 @@ class BuilderSpec extends AnyFlatSpec:
     val preservicaClient = testEntityClient(Map(co1Ref -> bitStreamInfoList1, co2Ref -> bitStreamInfoList2))
     val ocflService = testOcflService(Nil)
 
-    val entityIds: Seq[UUID] = Seq(co1Ref)
+    val entityIds: Seq[UUID] = Seq(co1Ref, co2Ref)
 
     val preservicaCoRows = Builder[IO](preservicaClient).run(entityIds).unsafeRunSync()
 
-    preservicaCoRows.length should equal(2)
+    preservicaCoRows.length should equal(3)
 
     preservicaCoRows.contains(CoRow(co1Ref, potentialParentRef, Some("co1FileFixity"))) should equal(true)
     preservicaCoRows.contains(CoRow(co1Ref, potentialParentRef, Some("co1FileFixity2"))) should equal(true)
+    preservicaCoRows.contains(CoRow(co2Ref, potentialParentRef, Some("co2FileFixity"))) should equal(true)
   }
 
   private def createObjectVersionFile(path: String, fixityMap: Map[DigestAlgorithm, String]) =

--- a/custodial-copy-reconciler/src/test/scala/uk/gov/nationalarchives/reconciler/DatabaseSpec.scala
+++ b/custodial-copy-reconciler/src/test/scala/uk/gov/nationalarchives/reconciler/DatabaseSpec.scala
@@ -159,6 +159,20 @@ class DatabaseSpec extends AnyFlatSpec with BeforeAndAfterEach:
     result.ccCOsMissingFromPs should be(Nil)
   }
 
+  "deleteFromTables" should "delete all rows from both tables" in {
+    createPreservicaCOsTable()
+    createOcflCOsTable()
+    (createPSCoRow(coRef, ioRef, Some("checksum1")) >> createCoRow(coRef, ioRef, Some("checksum1"))).unsafeRunSync()
+
+    countPreservicaCORows() should equal(1)
+    countOcflCORows() should equal(1)
+
+    Database[IO].deleteFromTables().unsafeRunSync()
+
+    countPreservicaCORows() should equal(0)
+    countOcflCORows() should equal(0)
+  }
+
   forAll(checksumMismatchPossibilities) { (mismatch, ocflChecksum, preservicaChecksum) =>
     "findAllMissingCOs" should s"should return a message for each CO if $mismatch" in {
       createPreservicaCOsTable()

--- a/custodial-copy-reconciler/src/test/scala/uk/gov/nationalarchives/reconciler/MainSpec.scala
+++ b/custodial-copy-reconciler/src/test/scala/uk/gov/nationalarchives/reconciler/MainSpec.scala
@@ -22,10 +22,10 @@ import java.util.UUID
 class MainSpec extends AnyFlatSpec with BeforeAndAfterEach {
 
   val databaseName = "test-database"
+  val databaseUtils = new DatabaseUtils(databaseName)
 
   override def beforeEach(): Unit = {
     Files.deleteIfExists(Path.of(databaseName))
-    val databaseUtils = new DatabaseUtils(databaseName)
     databaseUtils.createPreservicaCOsTable()
     databaseUtils.createOcflCOsTable()
   }
@@ -121,5 +121,22 @@ class MainSpec extends AnyFlatSpec with BeforeAndAfterEach {
     val eventBridgeEvents = runTestReconciler(entities, List(bitStreamInfo))
 
     eventBridgeEvents.size should equal(0)
+  }
+
+  "runReconciler" should "empty both database tables before starting" in {
+    val repoDir = Files.createTempDirectory("repo").toString
+    val workDir = Files.createTempDirectory("work").toString
+
+    databaseUtils.createPreservicaCORow()
+    databaseUtils.createOcflCORow()
+
+    databaseUtils.countOcflCORows() should equal(1)
+    databaseUtils.countPreservicaCORows() should equal(1)
+
+    given Configuration = configuration(repoDir, workDir)
+    runTestReconciler(Nil, Nil)
+
+    databaseUtils.countOcflCORows() should equal(0)
+    databaseUtils.countPreservicaCORows() should equal(0)
   }
 }

--- a/custodial-copy-reconciler/src/test/scala/uk/gov/nationalarchives/reconciler/OcflServiceSpec.scala
+++ b/custodial-copy-reconciler/src/test/scala/uk/gov/nationalarchives/reconciler/OcflServiceSpec.scala
@@ -48,7 +48,7 @@ class OcflServiceSpec extends AnyFlatSpec {
     }
   }
 
-  "getAllObjectFiles" should "not return access copies" in {
+  "getAllObjectFiles" should "return access copies" in {
     val (repoDir, workDir) = (Files.createTempDirectory("repo").toString, Files.createTempDirectory("work").toString)
     val repository = createOcflRepository(repoDir, workDir)
     val preservationId = UUID.randomUUID
@@ -70,11 +70,16 @@ class OcflServiceSpec extends AnyFlatSpec {
     )
     val config = Config("", "test-database", 1, repoDir, workDir)
     val allFiles = OcflService[IO](config).getAllObjectFiles.compile.toList.unsafeRunSync()
-    allFiles.length should equal(1)
+    allFiles.length should equal(2)
 
-    val file = allFiles.head
-    file.id should equal(preservationId)
-    file.parent.get should equal(id)
-    file.sha256Checksum.get should equal(DigestUtils.sha256Hex(preservationId.toString))
+    val preservationFile = allFiles.head
+    preservationFile.id should equal(preservationId)
+    preservationFile.parent.get should equal(id)
+    preservationFile.sha256Checksum.get should equal(DigestUtils.sha256Hex(preservationId.toString))
+
+    val accessFile = allFiles.last
+    accessFile.id should equal(accessId)
+    accessFile.parent.get should equal(id)
+    accessFile.sha256Checksum.get should equal(DigestUtils.sha256Hex(accessId.toString))
   }
 }

--- a/custodial-copy-reconciler/src/test/scala/uk/gov/nationalarchives/reconciler/OcflServiceSpec.scala
+++ b/custodial-copy-reconciler/src/test/scala/uk/gov/nationalarchives/reconciler/OcflServiceSpec.scala
@@ -72,14 +72,8 @@ class OcflServiceSpec extends AnyFlatSpec {
     val allFiles = OcflService[IO](config).getAllObjectFiles.compile.toList.unsafeRunSync()
     allFiles.length should equal(2)
 
-    val preservationFile = allFiles.head
-    preservationFile.id should equal(preservationId)
-    preservationFile.parent.get should equal(id)
-    preservationFile.sha256Checksum.get should equal(DigestUtils.sha256Hex(preservationId.toString))
+    allFiles.contains(CoRow(preservationId, Option(id), Option(DigestUtils.sha256Hex(preservationId.toString)))) should equal(true)
+    allFiles.contains(CoRow(accessId, Option(id), Option(DigestUtils.sha256Hex(accessId.toString)))) should equal(true)
 
-    val accessFile = allFiles.last
-    accessFile.id should equal(accessId)
-    accessFile.parent.get should equal(id)
-    accessFile.sha256Checksum.get should equal(DigestUtils.sha256Hex(accessId.toString))
   }
 }

--- a/custodial-copy-reconciler/src/test/scala/uk/gov/nationalarchives/reconciler/OcflServiceSpec.scala
+++ b/custodial-copy-reconciler/src/test/scala/uk/gov/nationalarchives/reconciler/OcflServiceSpec.scala
@@ -1,0 +1,80 @@
+package uk.gov.nationalarchives.reconciler
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import io.ocfl.api.model.{ObjectVersionId, VersionInfo}
+import org.apache.commons.codec.digest.DigestUtils
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers.*
+import uk.gov.nationalarchives.reconciler.Main.Config
+import uk.gov.nationalarchives.utils.Utils.*
+
+import java.nio.file.{Files, Path}
+import java.util.UUID
+
+class OcflServiceSpec extends AnyFlatSpec {
+
+  "getAllObjectFiles" should "return all files in the repository" in {
+    val (repoDir, workDir) = (Files.createTempDirectory("repo").toString, Files.createTempDirectory("work").toString)
+    val repository = createOcflRepository(repoDir, workDir)
+    val id = UUID.randomUUID
+
+    case class IdPath(preservationId: UUID, path: Path)
+
+    val idsPaths = List.fill(100)(UUID.randomUUID).map { preservationId =>
+      val preservationTestFile = Files.createTempFile(preservationId.toString, "file")
+      val path = Files.write(preservationTestFile, preservationId.toString.getBytes)
+      IdPath(preservationId, path)
+    }
+    repository.updateObject(
+      ObjectVersionId.head(id.toString),
+      new VersionInfo(),
+      updater => {
+        idsPaths.map { idPath =>
+          updater
+            .addPath(idPath.path, s"$id/Preservation_1/${idPath.preservationId}")
+        }
+      }
+    )
+
+    val config = Config("", "test-database", 1, repoDir, workDir)
+    val allFiles = OcflService[IO](config).getAllObjectFiles.compile.toList.unsafeRunSync()
+    allFiles.length should equal(100)
+
+    idsPaths.map(_.preservationId).map { preservationId =>
+      val file = allFiles.find(_.id == preservationId).get
+      file.parent.get should equal(id)
+      file.sha256Checksum.get should equal(DigestUtils.sha256Hex(preservationId.toString))
+    }
+  }
+
+  "getAllObjectFiles" should "not return access copies" in {
+    val (repoDir, workDir) = (Files.createTempDirectory("repo").toString, Files.createTempDirectory("work").toString)
+    val repository = createOcflRepository(repoDir, workDir)
+    val preservationId = UUID.randomUUID
+    val accessId = UUID.randomUUID
+    val preservationTestFile = Files.createTempFile("test_ps", "file")
+    Files.write(preservationTestFile, preservationId.toString.getBytes)
+    val accessTestFile = Files.createTempFile("test_access", "file")
+    Files.write(accessTestFile, accessId.toString.getBytes)
+    val id = UUID.randomUUID
+
+    repository.updateObject(
+      ObjectVersionId.head(id.toString),
+      new VersionInfo(),
+      updater => {
+        updater
+          .addPath(preservationTestFile, s"$id/Preservation_1/$preservationId")
+          .addPath(accessTestFile, s"$id/Access_1/$accessId")
+      }
+    )
+    val config = Config("", "test-database", 1, repoDir, workDir)
+    val allFiles = OcflService[IO](config).getAllObjectFiles.compile.toList.unsafeRunSync()
+    allFiles.length should equal(1)
+
+    val file = allFiles.head
+    file.id should equal(preservationId)
+    file.parent.get should equal(id)
+    file.sha256Checksum.get should equal(DigestUtils.sha256Hex(preservationId.toString))
+  }
+}

--- a/utils/src/main/scala/uk/gov/nationalarchives/utils/TestUtils.scala
+++ b/utils/src/main/scala/uk/gov/nationalarchives/utils/TestUtils.scala
@@ -63,6 +63,16 @@ object TestUtils:
       transaction.transact(xa).unsafeRunSync()
     }
 
+    def createPreservicaCORow(): Unit = sql"INSERT INTO PreservicaCOs SELECT 1,1,1".update.run.transact(xa).unsafeRunSync()
+
+    def createOcflCORow(): Unit = sql"INSERT INTO OcflCOs SELECT 1,1,1".update.run.transact(xa).unsafeRunSync()
+
+    def countPreservicaCORows(): Int =
+      sql"SELECT count(*) FROM PreservicaCOs;".query[Int].unique.transact(xa).unsafeRunSync()
+
+    def countOcflCORows(): Int =
+      sql"SELECT count(*) FROM OcflCOs;".query[Int].unique.transact(xa).unsafeRunSync()
+
     def addColumn(columnName: String): Unit =
       (fr"ALTER TABLE files ADD COLUMN" ++ Fragment.const(columnName)).update.run.transact(xa).unsafeRunSync()
 


### PR DESCRIPTION
~~We're filtering those from Preservica so we should do the same here.~~
I've changed my mind. The reconciler keeps finding the same files that look like they're Preservation representations but they're under an Acess path so for the sake of a few extra minutes runtime, we'll include the access ones.

~~Looking at the current code, we're not actually excluding access copies from Preservica so this should help.~~
We were excluding access copies from Preservica. I've changed this as well.

I've also added a method to delete from the two tables before the
reconciler starts and added some tests for the OCFL service.
