### PR TITLE
Ignore empty checksums

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,28 +363,15 @@ two storage mediums to become out of sync. We are only concerned with original n
 
 ### The process
 
-1. Make a call to Preservica to stream the refs of every entity we have stored
-2. It will filter out anything that is not an IO ref nor CO ref
+1. Stream every entity from Preservica via paginated calls to the `updated-since` endpoint.
+2. It will filter out anything that is not a CO ref.
 3. Splits the remaining object refs into Chunks:
 4. Run this process for each Chunk:
-   1. if the object ref if an Information Object one, it will
-      1. get all the object files from OCFL
-      2. if the object is a CO content file
-         1. get the storage path and extract the CO ref
-         2. get the sha256 fixity of the CO
-         3. add each of these values (including the IO ref) to an `OcflCoRow` object
-   2. if the object ref is a Content Object one, it will:
-      1. get the bitstream info from Preservica
-      2. filter it out if it's a non-Original and non-Preservation CO (The opposite of "Preservation" is "Access")
-      3. retrieve the IO ref and sha256 checksum
-      4. add each of these values to an `PreservicaCoRow` object
-   3. Return these `CoRow`s in a Chunk
-5. For each `CoRow` object
-   1. gather all `PreservicaCoRow`s into a Chunk
-   2. gather all `OcflCoRow`s into a Chunk
-   3. write the Chunk of `PreservicaCoRow`s to a table
-   4. write the Chunk of `OcflCoRow`s to another table
-6. Now that they have been saved to the tables, the stream can be drained (in order to discard anything returned)
+   1. get the bitstream info from Preservica
+   2. retrieve the IO ref and sha256 checksum
+   3. Return these `CoRow`s
+5. There is a parallel process which streams all OCFL objects from the repository and writes them in chunks to the database. 
+6. Once both processes have completed and all rows have been written to the database, the stream can be drained (in order to discard anything returned)
 7. Find the missing COs in each table
    1. first parse the `PreservicaCOs` table and check if the checksum(s) appear in the `OcflCos` table
       1. if not, for each missing CO

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ two storage mediums to become out of sync. We are only concerned with original n
 3. Splits the remaining object refs into Chunks:
 4. Run this process for each Chunk:
    1. get the bitstream info from Preservica
-   2. retrieve the IO ref and sha256 checksum
+   2. retrieve the IO ref and sha256 checksum. If there is no checksum (as is the case for files extracted from email attachments), then this CO is ignored.
    3. Return these `CoRow`s
 5. There is a parallel process which streams all OCFL objects from the repository and writes them in chunks to the database. 
 6. Once both processes have completed and all rows have been written to the database, the stream can be drained (in order to discard anything returned)

--- a/custodial-copy-reconciler/src/main/scala/uk/gov/nationalarchives/reconciler/Builder.scala
+++ b/custodial-copy-reconciler/src/main/scala/uk/gov/nationalarchives/reconciler/Builder.scala
@@ -17,10 +17,15 @@ object Builder:
     (entityIds: Seq[UUID]) =>
       entityIds.toList.flatTraverse { entityId =>
         client.getBitstreamInfo(entityId).map { bitstreamInfoForCo =>
-          bitstreamInfoForCo.map { bitstreamInfo =>
-            val potentialSha256 = bitstreamInfo.fixities.collectFirst { case fixity if fixity.algorithm.toLowerCase == "sha256" => fixity.value }
-            CoRow(entityId, bitstreamInfo.parentRef, potentialSha256)
-          }.toList
-
+          bitstreamInfoForCo
+            .map { bitstreamInfo =>
+              bitstreamInfo.fixities
+                .collectFirst { case fixity if fixity.algorithm.toLowerCase == "sha256" => fixity.value }
+                .map { sha256 =>
+                  CoRow(entityId, bitstreamInfo.parentRef, sha256)
+                }
+            }
+            .toList
+            .flatten
         }
       }

--- a/custodial-copy-reconciler/src/main/scala/uk/gov/nationalarchives/reconciler/Builder.scala
+++ b/custodial-copy-reconciler/src/main/scala/uk/gov/nationalarchives/reconciler/Builder.scala
@@ -20,10 +20,7 @@ object Builder:
           bitstreamInfoForCo
             .map { bitstreamInfo =>
               bitstreamInfo.fixities
-                .collectFirst { case fixity if fixity.algorithm.toLowerCase == "sha256" => fixity.value }
-                .map { sha256 =>
-                  CoRow(entityId, bitstreamInfo.parentRef, sha256)
-                }
+                .collectFirst { case fixity if fixity.algorithm.toLowerCase == "sha256" => CoRow(entityId, bitstreamInfo.parentRef, fixity.value) }
             }
             .toList
             .flatten

--- a/custodial-copy-reconciler/src/main/scala/uk/gov/nationalarchives/reconciler/Database.scala
+++ b/custodial-copy-reconciler/src/main/scala/uk/gov/nationalarchives/reconciler/Database.scala
@@ -116,7 +116,7 @@ object Database:
 case class CoRow(
     id: UUID,
     parent: Option[UUID],
-    sha256Checksum: Option[String]
+    sha256Checksum: String
 )
 
 case class Result(

--- a/custodial-copy-reconciler/src/main/scala/uk/gov/nationalarchives/reconciler/OcflService.scala
+++ b/custodial-copy-reconciler/src/main/scala/uk/gov/nationalarchives/reconciler/OcflService.scala
@@ -58,8 +58,8 @@ object OcflService {
           val pathStartingFromRepType = pathAsList.dropWhile(pathPart => !pathPart.startsWith("Preservation_") && !pathPart.startsWith("Access_"))
           val coRef = UUID.fromString(pathStartingFromRepType(1))
           val fixities = coFile.getFixity.asScala.toMap.map { case (digestAlgo, value) => (digestAlgo.getOcflName, value) }
-          val potentialSha256 = fixities.get("sha256")
-          CoRow(coRef, Option(ioRef), potentialSha256)
+          val sha256 = fixities("sha256")
+          CoRow(coRef, Option(ioRef), sha256)
       }
       Async[F].pure(chunk)
     }

--- a/custodial-copy-reconciler/src/test/scala/uk/gov/nationalarchives/reconciler/BuilderSpec.scala
+++ b/custodial-copy-reconciler/src/test/scala/uk/gov/nationalarchives/reconciler/BuilderSpec.scala
@@ -38,9 +38,9 @@ class BuilderSpec extends AnyFlatSpec:
 
     preservicaCoRows.length should equal(3)
 
-    preservicaCoRows.contains(CoRow(co1Ref, potentialParentRef, Some("co1FileFixity"))) should equal(true)
-    preservicaCoRows.contains(CoRow(co1Ref, potentialParentRef, Some("co1FileFixity2"))) should equal(true)
-    preservicaCoRows.contains(CoRow(co2Ref, potentialParentRef, Some("co2FileFixity"))) should equal(true)
+    preservicaCoRows.contains(CoRow(co1Ref, potentialParentRef, "co1FileFixity")) should equal(true)
+    preservicaCoRows.contains(CoRow(co1Ref, potentialParentRef, "co1FileFixity2")) should equal(true)
+    preservicaCoRows.contains(CoRow(co2Ref, potentialParentRef, "co2FileFixity")) should equal(true)
   }
 
   private def createObjectVersionFile(path: String, fixityMap: Map[DigestAlgorithm, String]) =

--- a/custodial-copy-reconciler/src/test/scala/uk/gov/nationalarchives/reconciler/OcflServiceSpec.scala
+++ b/custodial-copy-reconciler/src/test/scala/uk/gov/nationalarchives/reconciler/OcflServiceSpec.scala
@@ -43,7 +43,7 @@ class OcflServiceSpec extends AnyFlatSpec {
     idPaths.map(_.preservationId).map { preservationId =>
       val file = allFiles.find(_.id == preservationId).get
       file.parent.get should equal(id)
-      file.sha256Checksum.get should equal(DigestUtils.sha256Hex(preservationId.toString))
+      file.sha256Checksum should equal(DigestUtils.sha256Hex(preservationId.toString))
     }
   }
 
@@ -70,8 +70,8 @@ class OcflServiceSpec extends AnyFlatSpec {
     val allFiles = OcflService[IO](config).getAllObjectFiles.compile.toList.unsafeRunSync()
     allFiles.length should equal(2)
 
-    allFiles.contains(CoRow(preservationId, Option(id), Option(DigestUtils.sha256Hex(preservationId.toString)))) should equal(true)
-    allFiles.contains(CoRow(accessId, Option(id), Option(DigestUtils.sha256Hex(accessId.toString)))) should equal(true)
+    allFiles.contains(CoRow(preservationId, Option(id), DigestUtils.sha256Hex(preservationId.toString))) should equal(true)
+    allFiles.contains(CoRow(accessId, Option(id), DigestUtils.sha256Hex(accessId.toString))) should equal(true)
 
   }
 }


### PR DESCRIPTION
There is one file (and potentially more in the future) which is an
extracted attachment from an email which doesn't have a checksum in
Preservica.

There's not much we can do about this so we're ignoring things that have
no checksum.

The risk that something has no checksum but isn't one of these extracted
files is acceptable. Every file in the OCFL repo has a checksum as well.