### PR TITLE
Use bistream id for db lookup.

### DIFF
--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Database.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Database.scala
@@ -8,10 +8,8 @@ import doobie.util.transactor.Transactor.Aux
 import doobie.util.{Get, Read}
 import uk.gov.nationalarchives.custodialcopy.Main.Config
 
-import java.util.UUID
-
 trait Database[F[_]]:
-  def getPathFromDri(fileId: UUID): F[Option[String]]
+  def getPathFromDri(fileId: String): F[Option[String]]
 
 object Database:
 
@@ -22,8 +20,8 @@ object Database:
       logHandler = Option(LogHandler.jdkLogHandler)
     )
 
-    override def getPathFromDri(fileId: UUID): F[Option[String]] = {
-      val selectSql = sql"select file_path from dri_files where file_id = ${fileId.toString}"
+    override def getPathFromDri(fileId: String): F[Option[String]] = {
+      val selectSql = sql"select file_path from dri_files where file_id = $fileId"
       selectSql.query[String].option.transact(xa)
     }
   }

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
@@ -249,7 +249,7 @@ class Processor(
           for
             logger <- Slf4jLogger.create[IO]
             potentialFilePath <- Database[IO](config).getPathFromDri(fo.tableItemIdentifier)
-            _ <- logger.info(s"Potential file path $potentialFilePath")
+            _ <- logger.info(s"Found path for bitstream name ${fo.tableItemIdentifier} in local cache")
             writePath <- fo.sourceFilePath(config.downloadDir)
             potentialWritePath <- {
               lazy val nioWritePath = Option(writePath.toNioPath)

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
@@ -247,7 +247,9 @@ class Processor(
         if isFileInRepository then IO.pure(IdWithSourceAndDestPaths(fo.id, None, fo.destinationFilePath))
         else
           for
-            potentialFilePath <- Database[IO](config).getPathFromDri(fo.id)
+            logger <- Slf4jLogger.create[IO]
+            potentialFilePath <- Database[IO](config).getPathFromDri(fo.tableItemIdentifier)
+            _ <- logger.info(s"Potential file path $potentialFilePath")
             writePath <- fo.sourceFilePath(config.downloadDir)
             potentialWritePath <- {
               lazy val nioWritePath = Option(writePath.toNioPath)

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/ProcessorTest.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/ProcessorTest.scala
@@ -110,8 +110,9 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEac
     val utils = new ProcessorTestUtils(ContentObject, cacheDir = true)
     val id = utils.coId
     val parentRef = utils.ioId
+    val bitstreamId = utils.bitstreamFromApi.name.split("\\.").head
 
-    databaseUtils.addFilesToDriFilesTable(List(DriFile(id.toString, utils.cachedFilePath.toString, parentRef.toString)))
+    databaseUtils.addFilesToDriFilesTable(List(DriFile(bitstreamId, utils.cachedFilePath, parentRef.toString)))
 
     utils.processMessage.unsafeRunSync()
 


### PR DESCRIPTION
We're populating the intelligent caching database with the fileId from
the DRI Preservica database. This fileId eventually becomes the bistream
name (with the file extension) so we need to use this to lookup if there
is a file in the database.
