### PR TITLE
Write completed status in intelligent caching DB.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Once the process completes successfully, a message per OCFL update is sent to SN
 
 #### Updating the downloaded status in the Intelligent Caching database
 If a file has been copied from the cache, we update the Intelligent Caching database with a boolean flag to show it has 
-been downloaded and the date it was downloaded.  
+been downloaded and the date it was downloaded. This will allow us to identify which files can be deleted from the cache. 
 
 #### Deleting Received SQS messages
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ Once the process completes successfully, a message per OCFL update is sent to SN
 * `ObjectType`: `Bitstream`, `Metadata`, `MetadataAndPotentialBitstreams`
 * `tableItemIdentifier` - the reference that can be used to find it in the files table
 
+#### Updating the downloaded status in the Intelligent Caching database
+If a file has been copied from the cache, we update the Intelligent Caching database with a boolean flag to show it has 
+been downloaded and the date it was downloaded.  
+
 #### Deleting Received SQS messages
 
 If the Custodial Copy process completes successfully, the messages that were received from SQS are then deleted from the

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Database.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Database.scala
@@ -1,6 +1,7 @@
 package uk.gov.nationalarchives.custodialcopy
 
 import cats.effect.Async
+import doobie.Update
 import doobie.implicits.*
 import doobie.util.log.LogHandler
 import doobie.util.transactor.Transactor
@@ -12,6 +13,8 @@ import java.util.UUID
 
 trait Database[F[_]]:
   def getPathFromDri(fileId: UUID): F[Option[String]]
+
+  def setAsDone(fileIds: List[String]): F[Int]
 
 object Database:
 
@@ -26,4 +29,9 @@ object Database:
       val selectSql = sql"select file_path from dri_files where file_id = ${fileId.toString}"
       selectSql.query[String].option.transact(xa)
     }
+
+    override def setAsDone(fileIds: List[String]): F[Int] =
+      val updateSql = "update dri_files set completed = true where file_id = ?"
+      Update[String](updateSql).updateMany(fileIds).transact(xa)
+
   }

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Database.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Database.scala
@@ -9,12 +9,13 @@ import doobie.util.transactor.Transactor.Aux
 import doobie.util.{Get, Read}
 import uk.gov.nationalarchives.custodialcopy.Main.Config
 
+import java.time.LocalDateTime
 import java.util.UUID
 
 trait Database[F[_]]:
   def getPathFromDri(fileId: UUID): F[Option[String]]
 
-  def setAsDone(fileIds: List[String]): F[Int]
+  def setAsDownloaded(fileIds: List[String]): F[Int]
 
 object Database:
 
@@ -30,8 +31,10 @@ object Database:
       selectSql.query[String].option.transact(xa)
     }
 
-    override def setAsDone(fileIds: List[String]): F[Int] =
-      val updateSql = "update dri_files set completed = true where file_id = ?"
-      Update[String](updateSql).updateMany(fileIds).transact(xa)
+    override def setAsDownloaded(fileIds: List[String]): F[Int] =
+      val currentDate = LocalDateTime.now.toString
+      val updates = fileIds.map(id => currentDate -> id)
+      val updateSql = "update dri_files set downloaded = true, downloaded_at = ? where file_id = ?"
+      Update[(String, String)](updateSql).updateMany(updates).transact(xa)
 
   }

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Main.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Main.scala
@@ -89,13 +89,13 @@ object Main extends IOApp {
           .parTraverse { case (potentialMessageGroupId, responses) =>
             potentialMessageGroupId match
               case Some(groupId) =>
-                processMessages(processor, responses, groupId)
+                processMessages(processor, responses, groupId, config)
               case None => IO.raiseError(new Exception("Message Group ID is missing"))
           }
           .map(_.flatten)
       }
 
-  private def processMessages(processor: Processor, responses: List[MessageResponse[ReceivedSnsMessage]], groupId: String) = {
+  private def processMessages(processor: Processor, responses: List[MessageResponse[ReceivedSnsMessage]], groupId: String, config: Config) = {
     for {
       logger <- Slf4jLogger.create[IO]
       _ <- logger.info(s"Processing ${responses.length} messages")
@@ -108,22 +108,23 @@ object Main extends IOApp {
         .map(_.toMap)
 
       results <- dedupedMessages.retainedMessages.traverse(processor.process)
-      removedResults = dedupedMessages.removedMessages.map(_.message.ref).map(Success.apply)
+      removedResults = dedupedMessages.removedMessages.map(r => (r.message.ref, Nil)).map(Success.apply)
 
       _ <- processor.commitStagedChanges(UUID.fromString(groupId))
       _ <- logger.info(s"${results.count(_.isSuccess)} out of ${results.length} unique messages processed successfully")
       _ <- logger.info(s"${results.count(_.isError)} out of ${results.length} unique messages failed")
 
       _ <- (results ++ removedResults).parTraverse {
-        case Failure(e)   => logError[IO](e)
-        case Success(ref) =>
-          responses
-            .filter(_.message.ref == ref)
-            .map(_.receiptHandle)
-            .parTraverse(receiptHandle =>
-              logger.info(s"Deleting message with receipt handle $receiptHandle") >> processor
-                .deleteMessage(receiptHandle) >> heartbeats.get(receiptHandle).traverse(_.cancel)
-            )
+        case Failure(e)          => logError[IO](e)
+        case Success(ref, icIds) =>
+          Database[IO](config).setAsDone(icIds) >>
+            responses
+              .filter(_.message.ref == ref)
+              .map(_.receiptHandle)
+              .parTraverse(receiptHandle =>
+                logger.info(s"Deleting message with receipt handle $receiptHandle") >> processor
+                  .deleteMessage(receiptHandle) >> heartbeats.get(receiptHandle).traverse(_.cancel)
+              )
       }
     } yield results
   }

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Main.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Main.scala
@@ -108,7 +108,7 @@ object Main extends IOApp {
         .map(_.toMap)
 
       results <- dedupedMessages.retainedMessages.traverse(processor.process)
-      removedResults = dedupedMessages.removedMessages.map(r => (r.message.ref, Nil)).map(Success.apply)
+      removedResults = dedupedMessages.removedMessages.map(r => Success(r.message.ref, Nil))
 
       _ <- processor.commitStagedChanges(UUID.fromString(groupId))
       _ <- logger.info(s"${results.count(_.isSuccess)} out of ${results.length} unique messages processed successfully")
@@ -117,7 +117,7 @@ object Main extends IOApp {
       _ <- (results ++ removedResults).parTraverse {
         case Failure(e)          => logError[IO](e)
         case Success(ref, icIds) =>
-          Database[IO](config).setAsDone(icIds) >>
+          Database[IO](config).setAsDownloaded(icIds) >>
             responses
               .filter(_.message.ref == ref)
               .map(_.receiptHandle)

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
@@ -420,10 +420,6 @@ object Processor {
 
     def isError: Boolean = !isSuccess
 
-    def getIcIds: List[String] = this match
-      case s: Result.Success => s.icIds
-      case _                 => Nil
-
     case Success(id: UUID, icIds: List[String])
     case Failure(ex: Throwable)
 }

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
@@ -391,7 +391,7 @@ class Processor(
         snsClient.publish[SendSnsMessage](config.topicArn)(snsMessages).void
       }
       _ <- logger.info(s"${snsMessages.length} 'created/updated objects' messages published to SNS")
-    } yield Success(messageResponse.message.ref)
+    } yield Success(messageResponse.message.ref, snsMessages.map(_.tableItemIdentifier))
   }.handleError(err => Failure(err))
 
   def commitStagedChanges(id: UUID): IO[Unit] = ocflService.commitStagedChanges(id)
@@ -420,6 +420,10 @@ object Processor {
 
     def isError: Boolean = !isSuccess
 
-    case Success(id: UUID)
+    def getIcIds: List[String] = this match
+      case s: Result.Success => s.icIds
+      case _                 => Nil
+
+    case Success(id: UUID, icIds: List[String])
     case Failure(ex: Throwable)
 }

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/MainTest.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/MainTest.scala
@@ -31,6 +31,7 @@ import uk.gov.nationalarchives.utils.TestUtils.*
 
 import java.nio.file
 import java.nio.file.{Files, Path, Paths}
+import java.time.{LocalDate, LocalDateTime}
 import java.util.UUID
 import scala.jdk.CollectionConverters.*
 import scala.concurrent.duration.*
@@ -154,15 +155,21 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues with Befo
       )
     }
 
-  "runCustodialCopy" should "set completed to true for any rows in the intelligent cache database" in {
+  "runCustodialCopy" should "set downloaded to true for the rows found in the intelligent cache database" in {
     val utils = new MainTestUtils(List((ContentObject, false)), objectVersion = 0)
     val parentRef = utils.ioId
     val bitstreamId = "90dfb573-7419-4e89-8558-6cfa29f8fb16"
+    val unusedBitstreamId = UUID.randomUUID.toString
+    databaseUtils.addFilesToDriFilesTable(List(DriFile(unusedBitstreamId, Files.createTempFile("dir", "file2").toString, utils.ioId.toString)))
     databaseUtils.addFilesToDriFilesTable(List(DriFile(bitstreamId, Files.createTempFile("dir", "file").toString, utils.ioId.toString)))
     runCustodialCopy(utils.sqsClient, utils.config, utils.processor)
 
-    val completedStatus = databaseUtils.getCompletedStatus(bitstreamId)
-    completedStatus.get must equal(1)
+    val downloadedStatus = databaseUtils.getDownloadedStatus(bitstreamId)
+    val unchangedDownloadStatus = databaseUtils.getDownloadedStatus(unusedBitstreamId)
+    downloadedStatus.downloaded.get must equal(1)
+    LocalDateTime.parse(downloadedStatus.downloadedAt.get).toLocalDate must equal(LocalDate.now)
+    unchangedDownloadStatus.downloaded must equal(None)
+    unchangedDownloadStatus.downloadedAt must equal(None)
   }
 
   "runCustodialCopy" should "only download a file once if there are IO and CO messages for the same IO" in {

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/MainTest.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/MainTest.scala
@@ -154,6 +154,17 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues with Befo
       )
     }
 
+  "runCustodialCopy" should "set completed to true for any rows in the intelligent cache database" in {
+    val utils = new MainTestUtils(List((ContentObject, false)), objectVersion = 0)
+    val parentRef = utils.ioId
+    val bitstreamId = "90dfb573-7419-4e89-8558-6cfa29f8fb16"
+    databaseUtils.addFilesToDriFilesTable(List(DriFile(bitstreamId, Files.createTempFile("dir", "file").toString, utils.ioId.toString)))
+    runCustodialCopy(utils.sqsClient, utils.config, utils.processor)
+
+    val completedStatus = databaseUtils.getCompletedStatus(bitstreamId)
+    completedStatus.get must equal(1)
+  }
+
   "runCustodialCopy" should "only download a file once if there are IO and CO messages for the same IO" in {
     val utils = new MainTestUtils(
       List((ContentObject, false), (InformationObject, false)),
@@ -872,8 +883,8 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues with Befo
       config,
       sqsClient,
       { messageResponse =>
-        if messageResponse.receiptHandle == "receiptHandleDelayed" then IO.sleep(4.seconds) >> IO.pure(Result.Success(delayedId))
-        else IO.pure(Result.Success(id))
+        if messageResponse.receiptHandle == "receiptHandleDelayed" then IO.sleep(4.seconds) >> IO.pure(Result.Success(delayedId, Nil))
+        else IO.pure(Result.Success(id, Nil))
       }
     )
 
@@ -921,8 +932,8 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues with Befo
       config,
       sqsClient,
       { messageResponse =>
-        if messageResponse.receiptHandle == "receiptHandleDelayed" then IO.sleep(4.seconds) >> IO.pure(Result.Success(delayedId))
-        else IO.pure(Result.Success(id))
+        if messageResponse.receiptHandle == "receiptHandleDelayed" then IO.sleep(4.seconds) >> IO.pure(Result.Success(delayedId, Nil))
+        else IO.pure(Result.Success(id, Nil))
       }
     )
 

--- a/utils/src/main/scala/uk/gov/nationalarchives/utils/TestUtils.scala
+++ b/utils/src/main/scala/uk/gov/nationalarchives/utils/TestUtils.scala
@@ -121,7 +121,7 @@ object TestUtils:
     def createDriFilesTable(): Unit = {
       val transaction = for {
         _ <- sql"DROP TABLE IF EXISTS dri_files;".update.run
-        _ <- sql"CREATE TABLE dri_files (file_id text, file_path text, asset_id text);".update.run
+        _ <- sql"CREATE TABLE dri_files (file_id text, file_path text, asset_id text, completed integer);".update.run
       } yield ()
       transaction.transact(xa).unsafeRunSync()
     }
@@ -134,6 +134,12 @@ object TestUtils:
     def addFilesToDriFilesTable(file: List[DriFile]): Unit = {
       val insert = "INSERT INTO dri_files (file_id, file_path, asset_id) values (?, ?, ?);"
       Update[DriFile](insert).updateMany(file).transact(xa).unsafeRunSync()
+    }
+
+    def getCompletedStatus(fileId: String): Option[Int] = {
+      val sql = sql"SELECT completed FROM dri_files where file_id = $fileId"
+      sql.query[Option[Int]].unique.transact(xa).unsafeRunSync()
+
     }
 
   def ocflFile(id: UUID, fileId: UUID, zref: String = "zref"): OcflFile =

--- a/utils/src/main/scala/uk/gov/nationalarchives/utils/TestUtils.scala
+++ b/utils/src/main/scala/uk/gov/nationalarchives/utils/TestUtils.scala
@@ -34,6 +34,8 @@ import scala.xml.Elem
 object TestUtils:
   case class DriFile(fileId: String, filePath: String, assetId: String)
 
+  case class DownloadedStatus(downloaded: Option[Int], downloadedAt: Option[String])
+
   class DatabaseUtils(val databaseName: String):
     val xa: Aux[IO, Unit] = Transactor.fromDriverManager[IO](
       driver = "org.sqlite.JDBC",
@@ -121,7 +123,7 @@ object TestUtils:
     def createDriFilesTable(): Unit = {
       val transaction = for {
         _ <- sql"DROP TABLE IF EXISTS dri_files;".update.run
-        _ <- sql"CREATE TABLE dri_files (file_id text, file_path text, asset_id text, completed integer);".update.run
+        _ <- sql"CREATE TABLE dri_files (file_id text, file_path text, asset_id text, downloaded integer, downloaded_at);".update.run
       } yield ()
       transaction.transact(xa).unsafeRunSync()
     }
@@ -136,9 +138,9 @@ object TestUtils:
       Update[DriFile](insert).updateMany(file).transact(xa).unsafeRunSync()
     }
 
-    def getCompletedStatus(fileId: String): Option[Int] = {
-      val sql = sql"SELECT completed FROM dri_files where file_id = $fileId"
-      sql.query[Option[Int]].unique.transact(xa).unsafeRunSync()
+    def getDownloadedStatus(fileId: String): DownloadedStatus = {
+      val sql = sql"SELECT downloaded, downloaded_at FROM dri_files where file_id = $fileId"
+      sql.query[DownloadedStatus].unique.transact(xa).unsafeRunSync()
 
     }
 


### PR DESCRIPTION
This now passes the bitstream ids back to the end of the process before
the sqs messages are deleted. It passes all ids so we're doing an update
statement in the database where there are potentially no rows to update.
This is fine, the statement itself will be fast and it's much better
than trying to figure out whether or not we actually got that particular
file from IC.
