### PR TITLE
Dr2 2874 add filepaths to dynamo from custodial copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,8 +348,10 @@ The queue sends messages in this format:
 ```
 
 For each message, the Confirmer checks to see if this object exists in the OCFL repository. 
-
-If it does exist, it writes `true` to an attribute specified by `DYNAMO_ATTRIBUTE_NAME` in the table specified by `DYNAMO_TABLE_NAME`. 
+If it exists, the confirmer gets a list of file paths of all the files which belong to this object. It updates the table specified by `DYNAMO_TABLE_NAME`.
+As part of the update, it updates two attributes in the table 
+1. An attribute specified by `DYNAMO_ATTRIBUTE_NAME` which is set to true
+2. An attribute called `input` which is set with JSON representation of the list of file paths of all files that belong to the object. 
 It has a conditional check on `attribute_exists(assetId)` in the table. This is to prevent repeated messages adding a row back in after it has been deleted by the change handler.
 If the row has been deleted, it doesn't matter because the asset has already been marked as complete so we ignore any errors related to the conditional check.
 It then deletes the message from the queue. 

--- a/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Main.scala
+++ b/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Main.scala
@@ -76,22 +76,16 @@ object Main extends IOApp {
         _ <- IO.whenA(messages.nonEmpty)(logger.info(s"Processing message refs ${messages.map(_.message.payload.preservationSystemId).mkString(",")}"))
         _ <- messages.parTraverse { sqsMessage =>
           val message = sqsMessage.message
-          val objectExists = ocfl.getFilePathsforObject(message.payload.preservationSystemId).nonEmpty
+          val objectFilePaths = ocfl.getFilePathsforObject(message.payload.preservationSystemId)
           val attributeUpdateMap = Map(config.dynamoAttributeName -> "true".toAttributeValue) ++
-            (if objectExists then
+            (if objectFilePaths.nonEmpty then
                Map(
                  "input" -> Json
-                   .obj(
-                     "filePaths" -> Json.fromValues(
-                       ocfl
-                         .getFilePathsforObject(message.payload.preservationSystemId)
-                         .map(Json.fromString)
-                     )
-                   )
+                   .obj("filePaths" -> Json.fromValues(objectFilePaths.map(Json.fromString)))
                    .noSpaces
                    .toAttributeValue
                )
-             else Map.empty[String, AttributeValue])
+             else Map())
           val request = DADynamoDbRequest(
             config.dynamoTableName,
             message.primaryKey,
@@ -99,9 +93,9 @@ object Main extends IOApp {
             Option("attribute_exists(assetId)")
           )
           logger.info(s"Object with assetId ${message.assetId} and preservation system ref ${message.payload.preservationSystemId} ${
-              if objectExists then "has been found" else "has not been found"
+              if objectFilePaths.nonEmpty then "has been found" else "has not been found"
             }") >>
-            IO.whenA(objectExists) {
+            IO.whenA(objectFilePaths.nonEmpty) {
               dynamoClient.updateAttributeValues(request).handleErrorWith {
                 case ce: ConditionalCheckFailedException => IO.unit
                 case e                                   => IO.raiseError(e)

--- a/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Main.scala
+++ b/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Main.scala
@@ -3,7 +3,7 @@ package uk.gov.nationalarchives.confirmer
 import cats.effect.{ExitCode, IO, IOApp}
 import cats.syntax.all.*
 import fs2.Stream
-import io.circe.{Decoder, DecodingFailure, HCursor}
+import io.circe.{Decoder, DecodingFailure, HCursor, Json}
 import io.circe.parser.decode
 import pureconfig.ConfigSource
 import uk.gov.nationalarchives.utils.Utils.*
@@ -76,13 +76,29 @@ object Main extends IOApp {
         _ <- IO.whenA(messages.nonEmpty)(logger.info(s"Processing message refs ${messages.map(_.message.payload.preservationSystemId).mkString(",")}"))
         _ <- messages.parTraverse { sqsMessage =>
           val message = sqsMessage.message
+          val objectExists = ocfl.getFilePathsforObject(message.payload.preservationSystemId).nonEmpty
+          val attributeUpdateMap = Map(config.dynamoAttributeName -> "true".toAttributeValue) ++
+            (if (objectExists) 
+              Map(
+                "input" -> Json 
+                  .obj(
+                    "filePaths" -> Json.fromValues(
+                        ocfl.getFilePathsforObject(message.payload.preservationSystemId)
+                          .map(Json.fromString)
+                    )  
+                  )
+                  .noSpaces
+                  .toAttributeValue
+              )
+            else 
+              Map.empty[String, AttributeValue]
+            )
           val request = DADynamoDbRequest(
             config.dynamoTableName,
             message.primaryKey,
-            Map(config.dynamoAttributeName -> "true".toAttributeValue),
+            attributeUpdateMap,
             Option("attribute_exists(assetId)")
           )
-          val objectExists = ocfl.checkObjectExists(message.payload.preservationSystemId)
           logger.info(s"Object with assetId ${message.assetId} and preservation system ref ${message.payload.preservationSystemId} ${
               if objectExists then "has been found" else "has not been found"
             }") >>

--- a/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Main.scala
+++ b/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Main.scala
@@ -78,21 +78,20 @@ object Main extends IOApp {
           val message = sqsMessage.message
           val objectExists = ocfl.getFilePathsforObject(message.payload.preservationSystemId).nonEmpty
           val attributeUpdateMap = Map(config.dynamoAttributeName -> "true".toAttributeValue) ++
-            (if (objectExists) 
-              Map(
-                "input" -> Json 
-                  .obj(
-                    "filePaths" -> Json.fromValues(
-                        ocfl.getFilePathsforObject(message.payload.preservationSystemId)
-                          .map(Json.fromString)
-                    )  
-                  )
-                  .noSpaces
-                  .toAttributeValue
-              )
-            else 
-              Map.empty[String, AttributeValue]
-            )
+            (if objectExists then
+               Map(
+                 "input" -> Json
+                   .obj(
+                     "filePaths" -> Json.fromValues(
+                       ocfl
+                         .getFilePathsforObject(message.payload.preservationSystemId)
+                         .map(Json.fromString)
+                     )
+                   )
+                   .noSpaces
+                   .toAttributeValue
+               )
+             else Map.empty[String, AttributeValue])
           val request = DADynamoDbRequest(
             config.dynamoTableName,
             message.primaryKey,

--- a/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Ocfl.scala
+++ b/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Ocfl.scala
@@ -10,13 +10,11 @@ import scala.jdk.CollectionConverters.*
 trait Ocfl(val config: Config):
   private[confirmer] lazy val repo: OcflRepository = createOcflRepository(config.ocflRepoDir, config.ocflWorkDir)
 
-  def getFilePathsforObject(id: UUID): List[String] 
+  def getFilePathsforObject(id: UUID): List[String]
 
 object Ocfl:
 
   def apply(config: Config): Ocfl = new Ocfl(config):
     override def getFilePathsforObject(id: UUID): List[String] =
-      if repo.containsObject(id.toString) then
-        repo.describeObject(id.toString).getHeadVersion.getFiles.asScala.map(_.getPath).toList
-      else
-        List.empty
+      if repo.containsObject(id.toString) then repo.describeObject(id.toString).getHeadVersion.getFiles.asScala.map(_.getPath).toList
+      else List.empty

--- a/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Ocfl.scala
+++ b/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Ocfl.scala
@@ -5,14 +5,18 @@ import uk.gov.nationalarchives.confirmer.Main.Config
 import uk.gov.nationalarchives.utils.Utils.createOcflRepository
 
 import java.util.UUID
+import scala.jdk.CollectionConverters.*
 
 trait Ocfl(val config: Config):
   private[confirmer] lazy val repo: OcflRepository = createOcflRepository(config.ocflRepoDir, config.ocflWorkDir)
 
-  def checkObjectExists(id: UUID): Boolean
+  def getFilePathsforObject(id: UUID): List[String] 
 
 object Ocfl:
 
   def apply(config: Config): Ocfl = new Ocfl(config):
-    override def checkObjectExists(id: UUID): Boolean =
-      repo.containsObject(id.toString)
+    override def getFilePathsforObject(id: UUID): List[String] =
+      if repo.containsObject(id.toString) then
+        repo.describeObject(id.toString).getHeadVersion.getFiles.asScala.map(_.getPath).toList
+      else
+        List.empty

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/MainTest.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/MainTest.scala
@@ -28,6 +28,7 @@ class MainTest extends AnyFlatSpec {
     updateItem.primaryKeyAndItsValue("assetId").s() should equal(existingAssetId.toString)
     updateItem.primaryKeyAndItsValue("batchId").s() should equal("batchId1")
     updateItem.attributeNamesAndValuesToUpdate("attribute").s() should equal("true")
+    updateItem.attributeNamesAndValuesToUpdate("input").s() should equal(s"""{"filePaths":["file1.txt","file2.txt"]}""")
     updateItem.conditionalExpression.get should equal("attribute_exists(assetId)")
   }
 

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/MainTest.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/MainTest.scala
@@ -28,7 +28,9 @@ class MainTest extends AnyFlatSpec {
     updateItem.primaryKeyAndItsValue("assetId").s() should equal(existingAssetId.toString)
     updateItem.primaryKeyAndItsValue("batchId").s() should equal("batchId1")
     updateItem.attributeNamesAndValuesToUpdate("attribute").s() should equal("true")
-    updateItem.attributeNamesAndValuesToUpdate("input").s() should equal(s"""{"filePaths":["/some/path/$existingRef/file1.txt","/some/path/$existingRef/file2.txt"]}""")
+    updateItem.attributeNamesAndValuesToUpdate("input").s() should equal(
+      s"""{"filePaths":["/some/path/$existingRef/file1.txt","/some/path/$existingRef/file2.txt"]}"""
+    )
     updateItem.conditionalExpression.get should equal("attribute_exists(assetId)")
   }
 

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/MainTest.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/MainTest.scala
@@ -28,7 +28,7 @@ class MainTest extends AnyFlatSpec {
     updateItem.primaryKeyAndItsValue("assetId").s() should equal(existingAssetId.toString)
     updateItem.primaryKeyAndItsValue("batchId").s() should equal("batchId1")
     updateItem.attributeNamesAndValuesToUpdate("attribute").s() should equal("true")
-    updateItem.attributeNamesAndValuesToUpdate("input").s() should equal(s"""{"filePaths":["file1.txt","file2.txt"]}""")
+    updateItem.attributeNamesAndValuesToUpdate("input").s() should equal(s"""{"filePaths":["/some/path/$existingRef/file1.txt","/some/path/$existingRef/file2.txt"]}""")
     updateItem.conditionalExpression.get should equal("attribute_exists(assetId)")
   }
 

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/OcflTest.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/OcflTest.scala
@@ -21,6 +21,6 @@ class OcflTest extends AnyFlatSpec:
     repository.putObject(ObjectVersionId.head(existingRef.toString), Files.createTempFile(existingRef.toString, ""), new VersionInfo())
 
     val ocfl = Ocfl(Config("table", "attribute", "", URI.create("http://localhost"), repoDir, workDir))
-    ocfl.checkObjectExists(existingRef) should equal(true)
-    ocfl.checkObjectExists(nonExistingRef) should equal(false)
+    ocfl.getFilePathsforObject(existingRef) should not be(List.empty) 
+    ocfl.getFilePathsforObject(nonExistingRef) should be(List.empty)
   }

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/OcflTest.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/OcflTest.scala
@@ -21,6 +21,6 @@ class OcflTest extends AnyFlatSpec:
     repository.putObject(ObjectVersionId.head(existingRef.toString), Files.createTempFile(existingRef.toString, ""), new VersionInfo())
 
     val ocfl = Ocfl(Config("table", "attribute", "", URI.create("http://localhost"), repoDir, workDir))
-    ocfl.getFilePathsforObject(existingRef) should not be List.empty 
+    ocfl.getFilePathsforObject(existingRef) should not be List.empty
     ocfl.getFilePathsforObject(nonExistingRef) should be(List.empty)
   }

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/OcflTest.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/OcflTest.scala
@@ -12,15 +12,16 @@ import java.util.UUID
 
 class OcflTest extends AnyFlatSpec:
 
-  "checkObjectExists" should "return true if an object exists or false otherwise" in {
+  "getFilePathsforObject" should "return valid paths if an object exists or empty list otherwise" in {
     val repoDir = Files.createTempDirectory("repo").toString
     val workDir = Files.createTempDirectory("work").toString
     val repository = createOcflRepository(repoDir, workDir)
     val existingRef = UUID.randomUUID
     val nonExistingRef = UUID.randomUUID
-    repository.putObject(ObjectVersionId.head(existingRef.toString), Files.createTempFile(existingRef.toString, ""), new VersionInfo())
+    val filePath = Files.createTempFile(existingRef.toString, "")
+    repository.putObject(ObjectVersionId.head(existingRef.toString), filePath, new VersionInfo())
 
     val ocfl = Ocfl(Config("table", "attribute", "", URI.create("http://localhost"), repoDir, workDir))
-    ocfl.getFilePathsforObject(existingRef) should not be List.empty
-    ocfl.getFilePathsforObject(nonExistingRef) should be(List.empty)
+    ocfl.getFilePathsforObject(existingRef) should be(List(filePath.getFileName.toString))
+    ocfl.getFilePathsforObject(nonExistingRef) should be(Nil)
   }

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/OcflTest.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/OcflTest.scala
@@ -21,6 +21,6 @@ class OcflTest extends AnyFlatSpec:
     repository.putObject(ObjectVersionId.head(existingRef.toString), Files.createTempFile(existingRef.toString, ""), new VersionInfo())
 
     val ocfl = Ocfl(Config("table", "attribute", "", URI.create("http://localhost"), repoDir, workDir))
-    ocfl.getFilePathsforObject(existingRef) should not be(List.empty) 
+    ocfl.getFilePathsforObject(existingRef) should not be List.empty 
     ocfl.getFilePathsforObject(nonExistingRef) should be(List.empty)
   }

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/TestUtils.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/TestUtils.scala
@@ -103,5 +103,5 @@ object TestUtils:
   }
 
   def ocfl(existingRefs: List[UUID], config: Config): Ocfl = new Ocfl(config) {
-    override def getFilePathsforObject(id: UUID): List[String] = if existingRefs.contains(id) then List("file1.txt", "file2.txt") else List.empty
+    override def getFilePathsforObject(id: UUID): List[String] = if existingRefs.contains(id) then List(s"/some/path/$id/file1.txt", s"/some/path/$id/file2.txt") else List.empty
   }

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/TestUtils.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/TestUtils.scala
@@ -103,5 +103,6 @@ object TestUtils:
   }
 
   def ocfl(existingRefs: List[UUID], config: Config): Ocfl = new Ocfl(config) {
-    override def getFilePathsforObject(id: UUID): List[String] = if existingRefs.contains(id) then List(s"/some/path/$id/file1.txt", s"/some/path/$id/file2.txt") else List.empty
+    override def getFilePathsforObject(id: UUID): List[String] =
+      if existingRefs.contains(id) then List(s"/some/path/$id/file1.txt", s"/some/path/$id/file2.txt") else List.empty
   }

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/TestUtils.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/TestUtils.scala
@@ -104,5 +104,5 @@ object TestUtils:
 
   def ocfl(existingRefs: List[UUID], config: Config): Ocfl = new Ocfl(config) {
     override def getFilePathsforObject(id: UUID): List[String] =
-      if existingRefs.contains(id) then List(s"/some/path/$id/file1.txt", s"/some/path/$id/file2.txt") else List.empty
+      if existingRefs.contains(id) then List(s"/some/path/$id/file1.txt", s"/some/path/$id/file2.txt") else Nil
   }

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/TestUtils.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/TestUtils.scala
@@ -103,5 +103,5 @@ object TestUtils:
   }
 
   def ocfl(existingRefs: List[UUID], config: Config): Ocfl = new Ocfl(config) {
-    override def getFilePathsforObject (id: UUID): List[String] = if existingRefs.contains(id) then List("file1.txt", "file2.txt") else List.empty
+    override def getFilePathsforObject(id: UUID): List[String] = if existingRefs.contains(id) then List("file1.txt", "file2.txt") else List.empty
   }

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/TestUtils.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/TestUtils.scala
@@ -103,5 +103,5 @@ object TestUtils:
   }
 
   def ocfl(existingRefs: List[UUID], config: Config): Ocfl = new Ocfl(config) {
-    override def checkObjectExists(id: UUID): Boolean = existingRefs.contains(id)
+    override def getFilePathsforObject (id: UUID): List[String] = if existingRefs.contains(id) then List("file1.txt", "file2.txt") else List.empty
   }


### PR DESCRIPTION
A small change in what custodial copy confirmer writes to the postingest state table.
It now updates the `input` field with the file paths corresponding to the assetID. Thus, it can be made available to the subsequent confirmers.
Actual change for TC will follow  