### PR TITLE
Pass all cache IDs into case class.

### DIFF
--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Message.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Message.scala
@@ -22,5 +22,5 @@ object Message {
   case class SoReceivedSnsMessage(ref: UUID) extends ReceivedSnsMessage
   case class DeletionReceivedSnsMessage(ref: UUID) extends ReceivedSnsMessage
 
-  case class SendSnsMessage(entityType: EntityType, ioRef: UUID, objectType: ObjectType, status: ObjectStatus, potentialIcId: Option[String])
+  case class SendSnsMessage(entityType: EntityType, ioRef: UUID, objectType: ObjectType, status: ObjectStatus, icIds: List[String])
 }

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Message.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Message.scala
@@ -22,5 +22,5 @@ object Message {
   case class SoReceivedSnsMessage(ref: UUID) extends ReceivedSnsMessage
   case class DeletionReceivedSnsMessage(ref: UUID) extends ReceivedSnsMessage
 
-  case class SendSnsMessage(entityType: EntityType, ioRef: UUID, objectType: ObjectType, status: ObjectStatus, icIds: List[String])
+  case class SendSnsMessage(entityType: EntityType, ioRef: UUID, objectType: ObjectType, status: ObjectStatus)
 }

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
@@ -347,8 +347,7 @@ class Processor(
       case _: SoReceivedSnsMessage => Option(StructuralObject)
       case _                       => None
 
-    val potentialIcId = filesDownloadedViaIc.find(_ == obj.tableItemIdentifier)
-    potentialEntityType.map(entityType => SendSnsMessage(entityType, obj.id, objectType, status, potentialIcId))
+    potentialEntityType.map(entityType => SendSnsMessage(entityType, obj.id, objectType, status, filesDownloadedViaIc))
   }
 
   given Encoder[SendSnsMessage] = (message: SendSnsMessage) => {
@@ -434,7 +433,7 @@ class Processor(
         snsClient.publish[SendSnsMessage](config.topicArn)(snsMessages).void
       }
       _ <- logger.info(s"${snsMessages.length} 'created/updated objects' messages published to SNS")
-      icIds = snsMessages.flatMap(_.potentialIcId)
+      icIds = snsMessages.flatMap(_.icIds)
       icIdsNum = icIds.length.toString
       _ <- logger.info(Map("icCacheHits" -> icIdsNum))(s"$icIdsNum files downloaded from IC")
     } yield Success(messageResponse.message.ref, icIds)

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
@@ -16,7 +16,7 @@ import uk.gov.nationalarchives.DASQSClient.MessageResponse
 import uk.gov.nationalarchives.custodialcopy.CustodialCopyObject.*
 import uk.gov.nationalarchives.custodialcopy.Main.{Config, FileDownloadInfo}
 import uk.gov.nationalarchives.custodialcopy.Message.*
-import uk.gov.nationalarchives.custodialcopy.Processor.{ObjectStatus, Result}
+import uk.gov.nationalarchives.custodialcopy.Processor.{ObjectStatus, ProcessorOutput, Result}
 import uk.gov.nationalarchives.custodialcopy.Processor.Result.*
 import uk.gov.nationalarchives.custodialcopy.Processor.ObjectStatus.{Created, Updated}
 import uk.gov.nationalarchives.custodialcopy.Processor.ObjectType.{Bitstream, Metadata}
@@ -331,7 +331,7 @@ class Processor(
     }
     .getOrElse("")
 
-  private def generateSnsMessage(filesDownloadedViaIc: List[String])(
+  private def generateSnsMessage(
       obj: CustodialCopyObject,
       receivedSnsMessage: ReceivedSnsMessage,
       status: ObjectStatus
@@ -347,7 +347,7 @@ class Processor(
       case _: SoReceivedSnsMessage => Option(StructuralObject)
       case _                       => None
 
-    potentialEntityType.map(entityType => SendSnsMessage(entityType, obj.id, objectType, status, filesDownloadedViaIc))
+    potentialEntityType.map(entityType => SendSnsMessage(entityType, obj.id, objectType, status))
   }
 
   given Encoder[SendSnsMessage] = (message: SendSnsMessage) => {
@@ -358,7 +358,7 @@ class Processor(
       .apply(message)
   }
 
-  private def processNonDeletedMessages(messageResponse: MessageResponse[ReceivedSnsMessage]): IO[List[SendSnsMessage]] =
+  private def processNonDeletedMessages(messageResponse: MessageResponse[ReceivedSnsMessage]): IO[ProcessorOutput] =
     val downloadFile = download(_, UUID.fromString(messageResponse.messageGroupId.get))
     for {
       logger <- Slf4jLogger.create[IO]
@@ -401,11 +401,10 @@ class Processor(
       _ <- allObjectPaths.flatMap(_.sourceNioFilePath).parTraverse(deleteObjectPath)
 
       filesDownloadedViaIc = allObjectPaths.flatMap(_.potentialIcId)
-      sqsMessage = generateSnsMessage(filesDownloadedViaIc)
 
-      createdObjsSnsMessages = missingAndChangedObjects.missingObjects.flatMap(sqsMessage(_, messageResponse.message, Created))
-      updatedObjsSnsMessages = missingAndChangedObjects.changedObjects.flatMap(sqsMessage(_, messageResponse.message, Updated))
-    } yield createdObjsSnsMessages ++ updatedObjsSnsMessages
+      createdObjsSnsMessages = missingAndChangedObjects.missingObjects.flatMap(generateSnsMessage(_, messageResponse.message, Created))
+      updatedObjsSnsMessages = missingAndChangedObjects.changedObjects.flatMap(generateSnsMessage(_, messageResponse.message, Updated))
+    } yield ProcessorOutput(createdObjsSnsMessages ++ updatedObjsSnsMessages, allObjectPaths.flatMap(_.potentialIcId))
 
   @tailrec
   private def deleteObjectPath(path: JPath): IO[Unit] = {
@@ -415,25 +414,25 @@ class Processor(
       deleteObjectPath(path.getParent)
   }
 
-  private def processDeletedEntities(messageResponse: MessageResponse[ReceivedSnsMessage]): IO[List[SendSnsMessage]] =
+  private def processDeletedEntities(messageResponse: MessageResponse[ReceivedSnsMessage]): IO[ProcessorOutput] =
     val ref = messageResponse.message.ref
     for {
       filePaths <- ocflService.getAllFilePathsOnAnObject(ref)
       _ <- ocflService.deleteObjects(ref, filePaths)
-    } yield Nil
+    } yield ProcessorOutput(Nil, Nil)
 
   def process(messageResponse: MessageResponse[ReceivedSnsMessage]): IO[Result] = {
     for {
       logger <- Slf4jLogger.create[IO]
-      snsMessages <-
+      processorOutput <-
         messageResponse.message match
           case DeletionReceivedSnsMessage(ref) => processDeletedEntities(messageResponse)
           case _                               => processNonDeletedMessages(messageResponse)
-      _ <- IO.whenA(snsMessages.nonEmpty) {
-        snsClient.publish[SendSnsMessage](config.topicArn)(snsMessages).void
+      _ <- IO.whenA(processorOutput.snsMessages.nonEmpty) {
+        snsClient.publish[SendSnsMessage](config.topicArn)(processorOutput.snsMessages).void
       }
-      _ <- logger.info(s"${snsMessages.length} 'created/updated objects' messages published to SNS")
-      icIds = snsMessages.flatMap(_.icIds)
+      _ <- logger.info(s"${processorOutput.snsMessages.length} 'created/updated objects' messages published to SNS")
+      icIds = processorOutput.icIds
       icIdsNum = icIds.length.toString
       _ <- logger.info(Map("icCacheHits" -> icIdsNum))(s"$icIdsNum files downloaded from IC")
     } yield Success(messageResponse.message.ref, icIds)
@@ -451,6 +450,8 @@ object Processor {
   ): IO[Processor] = IO(
     new Processor(config, sqsClient, ocflService, entityClient, ValidateXmlAgainstXsd[IO](XipXsdSchemaV7), snsClient)
   )
+
+  case class ProcessorOutput(snsMessages: List[SendSnsMessage], icIds: List[String])
 
   enum ObjectStatus:
     case Created, Updated

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/MainTest.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/MainTest.scala
@@ -160,7 +160,7 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues with Befo
     val bitstreamId2 = "de35982b-4a3a-48ad-888d-fe41f3532d36"
     val parentRef = UUID.randomUUID()
     val utils = new MainTestUtils(
-      List((ContentObject, false), (ContentObject, false)),
+      List((ContentObject, false), (InformationObject, false)),
       objectVersion = 0,
       true,
       bitstreamInfo1Responses = Seq(

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/ProcessorTest.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/ProcessorTest.scala
@@ -67,7 +67,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEac
       repTypes = Nil,
       repIndexes = Nil,
       createdFileDownloadInfo = List(Nil, List(FileDownloadInfo(id, Path(s"$id/IO_Metadata_changed.xml").toNioPath.some, "destinationPath"))),
-      snsMessagesToSend = List(SendSnsMessage(InformationObject, id, Metadata, Updated, None))
+      snsMessagesToSend = List(SendSnsMessage(InformationObject, id, Metadata, Updated, Nil))
     )
   }
 
@@ -98,8 +98,8 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEac
         )
       ),
       snsMessagesToSend = List(
-        SendSnsMessage(ContentObject, id, Bitstream, Created, None),
-        SendSnsMessage(ContentObject, id, Metadata, Created, None)
+        SendSnsMessage(ContentObject, id, Bitstream, Created, Nil),
+        SendSnsMessage(ContentObject, id, Metadata, Created, Nil)
       )
     )
   }
@@ -115,7 +115,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEac
     utils.processMessage.unsafeRunSync()
 
     val bitstreamCalls = 1
-    val potentialIcId = "90dfb573-7419-4e89-8558-6cfa29f8fb16".some
+    val icIds = List("90dfb573-7419-4e89-8558-6cfa29f8fb16")
 
     utils.verifyCallsAndArguments(
       bitstreamCalls,
@@ -135,8 +135,8 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEac
         )
       ),
       snsMessagesToSend = List(
-        SendSnsMessage(ContentObject, id, Bitstream, Created, potentialIcId),
-        SendSnsMessage(ContentObject, id, Metadata, Created, potentialIcId)
+        SendSnsMessage(ContentObject, id, Bitstream, Created, icIds),
+        SendSnsMessage(ContentObject, id, Metadata, Created, icIds)
       )
     )
   }
@@ -172,8 +172,8 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEac
         )
       ),
       snsMessagesToSend = List(
-        SendSnsMessage(ContentObject, id, Bitstream, Created, None),
-        SendSnsMessage(ContentObject, id, Metadata, Created, None)
+        SendSnsMessage(ContentObject, id, Bitstream, Created, Nil),
+        SendSnsMessage(ContentObject, id, Metadata, Created, Nil)
       )
     )
   }
@@ -255,7 +255,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEac
         ),
         Nil
       ),
-      snsMessagesToSend = List(SendSnsMessage(InformationObject, parentRef, Metadata, Created, None))
+      snsMessagesToSend = List(SendSnsMessage(InformationObject, parentRef, Metadata, Created, Nil))
     )
   }
 
@@ -286,8 +286,8 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEac
         )
       ),
       snsMessagesToSend = List(
-        SendSnsMessage(ContentObject, id, Bitstream, Created, None),
-        SendSnsMessage(ContentObject, id, Metadata, Created, None)
+        SendSnsMessage(ContentObject, id, Bitstream, Created, Nil),
+        SendSnsMessage(ContentObject, id, Metadata, Created, Nil)
       )
     )
   }
@@ -318,7 +318,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEac
         ) // 2nd call to 'createObjects' with changedObjectsPaths arg
       ),
       snsMessagesToSend = List(
-        SendSnsMessage(InformationObject, id, Metadata, Updated, None)
+        SendSnsMessage(InformationObject, id, Metadata, Updated, Nil)
       )
     )
   }
@@ -349,7 +349,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEac
         List()
       ),
       snsMessagesToSend = List(
-        SendSnsMessage(InformationObject, id, Metadata, Created, None)
+        SendSnsMessage(InformationObject, id, Metadata, Created, Nil)
       )
     )
   }
@@ -381,7 +381,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEac
         )
       ),
       snsMessagesToSend = List(
-        SendSnsMessage(InformationObject, changedFileId, Metadata, Updated, None)
+        SendSnsMessage(InformationObject, changedFileId, Metadata, Updated, Nil)
       )
     )
   }
@@ -427,7 +427,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEac
         )
       ),
       snsMessagesToSend = List(
-        SendSnsMessage(InformationObject, missingFileId, Metadata, Created, None)
+        SendSnsMessage(InformationObject, missingFileId, Metadata, Created, Nil)
       )
     )
   }

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/ProcessorTest.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/ProcessorTest.scala
@@ -67,7 +67,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEac
       repTypes = Nil,
       repIndexes = Nil,
       createdFileDownloadInfo = List(Nil, List(FileDownloadInfo(id, Path(s"$id/IO_Metadata_changed.xml").toNioPath.some, "destinationPath"))),
-      snsMessagesToSend = List(SendSnsMessage(InformationObject, id, Metadata, Updated, Nil))
+      snsMessagesToSend = List(SendSnsMessage(InformationObject, id, Metadata, Updated))
     )
   }
 
@@ -98,8 +98,8 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEac
         )
       ),
       snsMessagesToSend = List(
-        SendSnsMessage(ContentObject, id, Bitstream, Created, Nil),
-        SendSnsMessage(ContentObject, id, Metadata, Created, Nil)
+        SendSnsMessage(ContentObject, id, Bitstream, Created),
+        SendSnsMessage(ContentObject, id, Metadata, Created)
       )
     )
   }
@@ -135,8 +135,8 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEac
         )
       ),
       snsMessagesToSend = List(
-        SendSnsMessage(ContentObject, id, Bitstream, Created, icIds),
-        SendSnsMessage(ContentObject, id, Metadata, Created, icIds)
+        SendSnsMessage(ContentObject, id, Bitstream, Created),
+        SendSnsMessage(ContentObject, id, Metadata, Created)
       )
     )
   }
@@ -172,8 +172,8 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEac
         )
       ),
       snsMessagesToSend = List(
-        SendSnsMessage(ContentObject, id, Bitstream, Created, Nil),
-        SendSnsMessage(ContentObject, id, Metadata, Created, Nil)
+        SendSnsMessage(ContentObject, id, Bitstream, Created),
+        SendSnsMessage(ContentObject, id, Metadata, Created)
       )
     )
   }
@@ -255,7 +255,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEac
         ),
         Nil
       ),
-      snsMessagesToSend = List(SendSnsMessage(InformationObject, parentRef, Metadata, Created, Nil))
+      snsMessagesToSend = List(SendSnsMessage(InformationObject, parentRef, Metadata, Created))
     )
   }
 
@@ -286,8 +286,8 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEac
         )
       ),
       snsMessagesToSend = List(
-        SendSnsMessage(ContentObject, id, Bitstream, Created, Nil),
-        SendSnsMessage(ContentObject, id, Metadata, Created, Nil)
+        SendSnsMessage(ContentObject, id, Bitstream, Created),
+        SendSnsMessage(ContentObject, id, Metadata, Created)
       )
     )
   }
@@ -318,7 +318,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEac
         ) // 2nd call to 'createObjects' with changedObjectsPaths arg
       ),
       snsMessagesToSend = List(
-        SendSnsMessage(InformationObject, id, Metadata, Updated, Nil)
+        SendSnsMessage(InformationObject, id, Metadata, Updated)
       )
     )
   }
@@ -349,7 +349,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEac
         List()
       ),
       snsMessagesToSend = List(
-        SendSnsMessage(InformationObject, id, Metadata, Created, Nil)
+        SendSnsMessage(InformationObject, id, Metadata, Created)
       )
     )
   }
@@ -381,7 +381,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEac
         )
       ),
       snsMessagesToSend = List(
-        SendSnsMessage(InformationObject, changedFileId, Metadata, Updated, Nil)
+        SendSnsMessage(InformationObject, changedFileId, Metadata, Updated)
       )
     )
   }
@@ -427,7 +427,7 @@ class ProcessorTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEac
         )
       ),
       snsMessagesToSend = List(
-        SendSnsMessage(InformationObject, missingFileId, Metadata, Created, Nil)
+        SendSnsMessage(InformationObject, missingFileId, Metadata, Created)
       )
     )
   }


### PR DESCRIPTION
If we get a CO message, the code works and the downloaded column in the IC database
is set.

If it's an IO message, the `obj` in the `generateSnsMessage` method is the IO metadata object,
so when we do `filesDownloadedViaIc.find(_ == obj.tableItemIdentifier)` this returns None.

There is also a possiblity that an IO has more than one file in the IC cache database so for both cases
here this needs to be a list.
