### PR TITLE
DR2-2905 Add mock ScoutAM API.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
           java-version: "21"
       - uses: nationalarchives/ds-docker-actions/.github/actions/wiz-install-cli@a37bebac8d11fa61ca7a539863fe45cfa00cdfc6
       - run: |
+          python3 -m unittest discover -s custodial-copy-mock-tape-api -p "test_*.py"
           sbt scalafmtCheckAll test Docker/publishLocal scanDockerImage
         env:
           MANAGEMENT_ACCOUNT_NUMBER: 1

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ metals.sbt
 
 test-database
 test-ic-database.db
+
+__pycache__

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DR2 Custodial Copy
 
-This repository contains six components which together make up the custodial copy service.
+This repository contains seven components which together make up the custodial copy service.
 
 The principle of the Custodial Copy approach is described [here](https://zenodo.org/records/13647420)
 
@@ -418,3 +418,13 @@ two storage mediums to become out of sync.
 | OCFL_WORK_DIR          | The directory for the OCFL work directory                                                      |
 | DAYS_TO_IGNORE         | The number of days before the current date to ignore entities from Preservica and OCFL objects |
 | HTTPS_PROXY            | An optional proxy. This is needed running in TNA's network but not locally.                    |
+
+## 7. Custodial Copy Mock Tape API
+
+This Python service mocks the API provided by ScoutAM to determine whether files on disk have been written to tape.
+That API does not exist in our integration and staging environments, so this service allows us to keep the same behaviour in the calling service without environment-specific changes.
+
+It exposes two endpoints:
+
+1. `POST /v1/security/login` which returns a mock token payload.
+2. `GET /v1/file` which requires an `Authorization` header and returns a fixed mock tape-status payload.

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ def tagScannedImage(imageName: String): Unit = {
 def setupDirectories(serviceName: String) =
   Cmd(
     "RUN",
-    s"""apk update && apk upgrade && apk update openssl && apk add openjdk21-jre && \\
+    s"""apk update && apk upgrade && apk update openssl && apk add curl openjdk21-jre && \\
                |    mkdir -p /poduser/work /poduser/repo /poduser/version /poduser/database /poduser/log-config && \\
                |    mkdir /poduser/logs && \\
                |    touch /poduser/logs/$serviceName.log && \\
@@ -150,6 +150,31 @@ lazy val reconciler = (project in file("custodial-copy-reconciler"))
     )
   )
   .dependsOn(utils)
+
+
+lazy val mockTapeApi = (project in file("custodial-copy-mock-tape-api"))
+  .enablePlugins(DockerPlugin)
+  .settings(imageSettings)
+  .settings(
+    name := "custodial-copy-mock-tape-api",
+    publish / skip := true,
+
+    dockerRepository := Some(s"${sys.env.getOrElse("MANAGEMENT_ACCOUNT_NUMBER", "")}.dkr.ecr.eu-west-2.amazonaws.com"),
+    dockerBuildOptions ++= Seq("--no-cache", "--pull"),
+    Docker / packageName := s"dr2-${baseDirectory.value.getName}",
+    Docker / version := sys.env.getOrElse("DOCKER_TAG", version.value),
+
+    Docker / mappings := Seq(
+      (baseDirectory.value / "mock_tape_api.py") -> "app/mock_tape_api.py"
+    ),
+
+    dockerCommands := Seq(
+      Cmd("FROM", "python:3.15-rc-alpine"),
+      Cmd("WORKDIR", "/app"),
+      Cmd("COPY", "app/mock_tape_api.py", "/app/mock_tape_api.py"),
+      ExecCmd("CMD", "python", "mock_tape_api.py")
+    )
+  )
 
 lazy val imageSettings = {
   Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -169,7 +169,7 @@ lazy val mockTapeApi = (project in file("custodial-copy-mock-tape-api"))
     ),
 
     dockerCommands := Seq(
-      Cmd("FROM", "python:3.15-rc-alpine"),
+      Cmd("FROM", "python:3.14"),
       Cmd("WORKDIR", "/app"),
       Cmd("COPY", "app/mock_tape_api.py", "/app/mock_tape_api.py"),
       ExecCmd("CMD", "python", "mock_tape_api.py")

--- a/custodial-copy-mock-tape-api/mock_tape_api.py
+++ b/custodial-copy-mock-tape-api/mock_tape_api.py
@@ -1,0 +1,44 @@
+import socketserver
+from http.server import BaseHTTPRequestHandler
+import json
+from urllib.parse import urlparse
+
+PORT = 3000
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        self.check_path("/v1/security/login")
+        self.send_json({"response": "atoken"})
+        return
+
+
+    def do_GET(self):
+        if not self.headers.get("Authorization"):
+            self.send_error(401)
+        self.check_path("/v1/file")
+        body = {
+            "archdone": True,
+            "copies": [
+                {"copy": "1"},
+                {"copy": "2"},
+                {"copy": "3", "sections": [{"volume": "L03721"}]}
+            ]
+        }
+        self.send_json(body)
+
+
+    def check_path(self, expected_path):
+        parsed = urlparse(self.path)
+        if parsed.path != expected_path:
+            self.send_error(404)
+
+    def send_json(self, body):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(body).encode("utf-8"))
+
+
+with socketserver.TCPServer(("", PORT), Handler) as httpd:
+    print("serving at port", PORT)
+    httpd.serve_forever()

--- a/custodial-copy-mock-tape-api/mock_tape_api.py
+++ b/custodial-copy-mock-tape-api/mock_tape_api.py
@@ -4,33 +4,37 @@ import json
 from urllib.parse import urlparse
 
 PORT = 3000
+FILE_RESPONSE = {
+    "archdone": True,
+    "copies": [
+        {"copy": "1"},
+        {"copy": "2"},
+        {"copy": "3", "sections": [{"volume": "L03721"}]}
+    ]
+}
 
 class Handler(BaseHTTPRequestHandler):
     def do_POST(self):
-        self.check_path("/v1/security/login")
+        if not self.check_path("/v1/security/login"):
+            return
         self.send_json({"response": "atoken"})
-        return
 
 
     def do_GET(self):
         if not self.headers.get("Authorization"):
             self.send_error(401)
-        self.check_path("/v1/file")
-        body = {
-            "archdone": True,
-            "copies": [
-                {"copy": "1"},
-                {"copy": "2"},
-                {"copy": "3", "sections": [{"volume": "L03721"}]}
-            ]
-        }
-        self.send_json(body)
+            return
+        if not self.check_path("/v1/file"):
+            return
+        self.send_json(FILE_RESPONSE)
 
 
     def check_path(self, expected_path):
         parsed = urlparse(self.path)
         if parsed.path != expected_path:
             self.send_error(404)
+            return False
+        return True
 
     def send_json(self, body):
         self.send_response(200)
@@ -39,6 +43,11 @@ class Handler(BaseHTTPRequestHandler):
         self.wfile.write(json.dumps(body).encode("utf-8"))
 
 
-with socketserver.TCPServer(("", PORT), Handler) as httpd:
-    print("serving at port", PORT)
-    httpd.serve_forever()
+def run_server():
+    with socketserver.TCPServer(("", PORT), Handler) as httpd:
+        print("serving at port", PORT)
+        httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    run_server()

--- a/custodial-copy-mock-tape-api/test_mock_tape_api.py
+++ b/custodial-copy-mock-tape-api/test_mock_tape_api.py
@@ -1,0 +1,86 @@
+import io
+import json
+import unittest
+from unittest.mock import MagicMock
+
+from mock_tape_api import FILE_RESPONSE, Handler
+
+
+class MockTapeApiHandlerTests(unittest.TestCase):
+    def make_handler(self):
+        handler = Handler.__new__(Handler)
+        handler.send_error = MagicMock()
+        handler.send_response = MagicMock()
+        handler.send_header = MagicMock()
+        handler.end_headers = MagicMock()
+        handler.send_json = MagicMock()
+        return handler
+
+    def test_check_path_matches_expected_path(self):
+        handler = self.make_handler()
+        handler.path = "/v1/file?id=123"
+
+        is_valid = Handler.check_path(handler, "/v1/file")
+
+        self.assertTrue(is_valid)
+        handler.send_error.assert_not_called()
+
+    def test_check_path_sends_404_when_path_does_not_match(self):
+        handler = self.make_handler()
+        handler.path = "/v1/wrong"
+
+        is_valid = Handler.check_path(handler, "/v1/file")
+
+        self.assertFalse(is_valid)
+        handler.send_error.assert_called_once_with(404)
+
+    def test_do_get_sends_401_without_authorization_header(self):
+        handler = self.make_handler()
+        handler.path = "/v1/file"
+        handler.headers = {}
+        handler.check_path = MagicMock()
+
+        Handler.do_GET(handler)
+
+        handler.send_error.assert_called_once_with(401)
+        handler.check_path.assert_not_called()
+        handler.send_json.assert_not_called()
+
+    def test_do_get_returns_expected_json_for_authorized_request(self):
+        handler = self.make_handler()
+        handler.path = "/v1/file"
+        handler.headers = {"Authorization": "Bearer token"}
+
+        Handler.do_GET(handler)
+
+        handler.send_error.assert_not_called()
+        handler.send_json.assert_called_once_with(FILE_RESPONSE)
+
+    def test_send_json_writes_json_response(self):
+        handler = Handler.__new__(Handler)
+        handler.send_response = MagicMock()
+        handler.send_header = MagicMock()
+        handler.end_headers = MagicMock()
+        handler.wfile = io.BytesIO()
+
+        body = {"hello": "world"}
+        Handler.send_json(handler, body)
+
+        handler.send_response.assert_called_once_with(200)
+        handler.send_header.assert_called_once_with("Content-Type", "application/json")
+        handler.end_headers.assert_called_once()
+        self.assertEqual(handler.wfile.getvalue(), json.dumps(body).encode("utf-8"))
+
+    def test_do_post_sends_token_on_login_path(self):
+        handler = self.make_handler()
+        handler.path = "/v1/security/login"
+        handler.check_path = MagicMock(return_value=True)
+
+        Handler.do_POST(handler)
+
+        handler.check_path.assert_called_once_with("/v1/security/login")
+        handler.send_json.assert_called_once_with({"response": "atoken"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This provides two endpoints that we need for the confirmer.

`/v1/security/login` which returns a static response with a fake token.
`/v1/file` which allows any query parameters. This checks for an `Authorization` header and returns a static response if there is one.
