### PR TITLE
Set package name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -127,7 +127,7 @@ lazy val tapeConfirmer = (project in file("custodial-copy-confirmer"))
   .settings(
     target := (confirmer / baseDirectory).value / "target" / "custodial-copy-tape-confirmer",
     name := "custodial-copy-tape-confirmer",
-    packageName := "custodial-copy-tape-confirmer",
+    Docker / packageName := "dr2-custodial-copy-tape-confirmer",
     scalacOptions += "-Wunused:imports",
     assembly / assemblyJarName := "custodial-copy-tape-confirmer.jar",
     libraryDependencies ++= Seq(


### PR DESCRIPTION
This is the name that is used to build the image name. It defaults to the directory name so we need to override it.
