### PR TITLE
Confirmer fixes

### DIFF
--- a/custodial-copy-confirmer/src/main/resources/application.conf
+++ b/custodial-copy-confirmer/src/main/resources/application.conf
@@ -7,3 +7,4 @@ dynamo-attribute-name=${DYNAMO_ATTRIBUTE_NAME}
 scoutam-base-url=${?SCOUTAM_URL}
 scoutam-username=${?SCOUTAM_USERNAME}
 scoutam-password=${?SCOUTAM_PASSWORD}
+mount-root=${?MOUNT_ROOT}

--- a/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Models.scala
+++ b/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Models.scala
@@ -44,7 +44,8 @@ case class TCConfig(
     proxyUrl: Option[URI],
     scoutamBaseUrl: String,
     scoutamUsername: String,
-    scoutamPassword: String
+    scoutamPassword: String,
+    mountRoot: String
 ) extends Config derives ConfigReader
 
 extension (s: String) def toAttributeValue: AttributeValue = AttributeValue.builder.s(s).build

--- a/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Ocfl.scala
+++ b/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Ocfl.scala
@@ -15,5 +15,5 @@ object Ocfl:
 
   def apply(config: CCConfig): Ocfl = new Ocfl(config):
     override def getFilePathsForObject(id: UUID): List[String] =
-      if repo.containsObject(id.toString) then repo.describeObject(id.toString).getHeadVersion.getFiles.asScala.map(_.getPath).toList
+      if repo.containsObject(id.toString) then repo.describeObject(id.toString).getHeadVersion.getFiles.asScala.map(_.getStorageRelativePath).toList
       else List.empty

--- a/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/ScoutAM.scala
+++ b/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/ScoutAM.scala
@@ -7,6 +7,8 @@ import java.nio.charset.StandardCharsets
 import io.circe.parser.parse
 import io.circe.Json
 
+import java.nio.file.Path
+
 trait ScoutAM(config: TCConfig, httpService: ScoutAmHttpService):
   def getFileDetails(filePaths: List[String]): Map[String, List[String]]
 
@@ -14,7 +16,8 @@ object ScoutAM:
   def apply(config: TCConfig, httpService: ScoutAmHttpService): ScoutAM = new ScoutAM(config, httpService):
 
     private def getFileDetailsForPath(scoutAmBaseUrl: String, filePath: String, authorisationResponse: AuthorisationResponse): Either[Throwable, FileResponse] =
-      val encodedFilePath = URLEncoder.encode(filePath, StandardCharsets.UTF_8.toString)
+      val fullFilePath = Path.of(config.mountRoot, filePath).toString
+      val encodedFilePath = URLEncoder.encode(fullFilePath, StandardCharsets.UTF_8)
       val request = HttpRequest
         .newBuilder()
         .uri(URI.create(s"$scoutAmBaseUrl/v1/file?path=$encodedFilePath"))

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/ConfirmerTest.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/ConfirmerTest.scala
@@ -10,7 +10,13 @@ class ConfirmerTest extends AnyFlatSpec {
     Confirmer.getConfirmer(CCConfig("table", result_CC.toString, "", null, "", "")).getClass.getDeclaredFields.apply(1).getType.getSimpleName should equal(
       "Ocfl"
     )
-    Confirmer.getConfirmer(TCConfig("table", result_TC.toString, "", null, "", "", "")).getClass.getDeclaredFields.apply(1).getType.getSimpleName should equal(
+    Confirmer
+      .getConfirmer(TCConfig("table", result_TC.toString, "", null, "", "", "", "mountRoot"))
+      .getClass
+      .getDeclaredFields
+      .apply(1)
+      .getType
+      .getSimpleName should equal(
       "ScoutAM"
     )
   }
@@ -59,7 +65,7 @@ class ConfirmerTest extends AnyFlatSpec {
   "TC Confirmer getResult" should "return success when the payload and service is valid" in {
     val filePaths = List("file1.txt", "file2.txt")
     val tcPayload = TCPayload(filePaths)
-    val scoutAM = TestUtils.scoutAM(filePaths, TCConfig("table", result_TC.toString, "", null, "", "", ""))
+    val scoutAM = TestUtils.scoutAM(filePaths, TCConfig("table", result_TC.toString, "", null, "", "", "", "mountRoot"))
     val tcResult = Confirmer.tcConfirmer(scoutAM).getResult(tcPayload)
 
     tcResult.isSuccess should be(true)
@@ -73,7 +79,7 @@ class ConfirmerTest extends AnyFlatSpec {
 
   "TC Confirmer getResult" should "return failure when the payload is invalid" in {
     val ccPayload = CCPayload(java.util.UUID.randomUUID()) // Invalid payload for TC confirmer
-    val scountAM = TestUtils.scoutAM(List("file1.txt", "file2.txt"), TCConfig("table", result_TC.toString, "", null, "", "", ""))
+    val scountAM = TestUtils.scoutAM(List("file1.txt", "file2.txt"), TCConfig("table", result_TC.toString, "", null, "", "", "", "mountRoot"))
     val tcResult = Confirmer.tcConfirmer(scountAM).getResult(ccPayload)
 
     tcResult.isError should be(true)
@@ -87,7 +93,7 @@ class ConfirmerTest extends AnyFlatSpec {
   "TC Confirmer getResult" should "return failure when volumes cannot be found" in {
     val filePaths = List("file1.txt", "file2.txt")
     val tcPayload = TCPayload(filePaths)
-    val scoutAM = TestUtils.scoutAM(filePaths, TCConfig("table", result_TC.toString, "", null, "", "", ""), ScoutAmErrors(true))
+    val scoutAM = TestUtils.scoutAM(filePaths, TCConfig("table", result_TC.toString, "", null, "", "", "", "mountRoot"), ScoutAmErrors(true))
     val tcResult = Confirmer.tcConfirmer(scoutAM).getResult(tcPayload)
 
     tcResult.isError should be(true)

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/ModelsTest.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/ModelsTest.scala
@@ -205,7 +205,8 @@ class ModelsTest extends org.scalatest.flatspec.AnyFlatSpec {
         |   "dynamo-attribute-name": "result_TC",
         |   "scoutam-base-url":"http://scoutam-base:8080",
         |   "scoutam-username": "Scotty",
-        |   "scoutam-password": "Beam Me"
+        |   "scoutam-password": "Beam Me",
+        |   "mount-root": "/mnt"
         |}
         |""".stripMargin
 

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/OcflTest.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/OcflTest.scala
@@ -1,6 +1,7 @@
 package uk.gov.nationalarchives.confirmer
 
-import io.ocfl.api.model.{ObjectVersionId, VersionInfo}
+import io.ocfl.api.model.{DigestAlgorithm, ObjectVersionId, VersionInfo}
+import io.ocfl.core.util.DigestUtil
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers.*
 import uk.gov.nationalarchives.utils.Utils.createOcflRepository
@@ -19,8 +20,9 @@ class OcflTest extends AnyFlatSpec:
     val nonExistingRef = UUID.randomUUID
     val filePath = Files.createTempFile(existingRef.toString, "")
     repository.putObject(ObjectVersionId.head(existingRef.toString), filePath, new VersionInfo())
-
+    val refHex = DigestUtil.computeDigestHex(DigestAlgorithm.fromOcflName("sha256"), existingRef.toString)
+    val path = s"${refHex.slice(0, 3)}/${refHex.slice(3, 6)}/${refHex.slice(6, 9)}/$refHex/v1/content"
     val ocfl = Ocfl(CCConfig("table", "attribute", "", Some(URI.create("http://localhost")), repoDir, workDir))
-    ocfl.getFilePathsForObject(existingRef) should be(List(filePath.getFileName.toString))
+    ocfl.getFilePathsForObject(existingRef) should be(List(s"$path/${filePath.getFileName}"))
     ocfl.getFilePathsForObject(nonExistingRef) should be(Nil)
   }

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/ScoutAMTest.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/ScoutAMTest.scala
@@ -8,7 +8,7 @@ import java.net.http.{HttpRequest, HttpResponse}
 class ScoutAMTest extends org.scalatest.flatspec.AnyFlatSpec {
   "ScoutAM" should "return a valid instance of ScoutAM based on the config" in {
     val scoutAM = ScoutAM(
-      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password"),
+      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot"),
       new TestHttpService()
     )
     scoutAM shouldBe a[ScoutAM]
@@ -27,7 +27,7 @@ class ScoutAMTest extends org.scalatest.flatspec.AnyFlatSpec {
         |   "checksum": "someChecksumValue"
         |}""".stripMargin
     val scoutAM = ScoutAM(
-      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password"),
+      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot"),
       new TestHttpService("", responseForFileDetails, 200, 200)
     )
     val details = scoutAM.getFileDetails(List("/tmp/file1", "/tmp/file2"))
@@ -47,7 +47,7 @@ class ScoutAMTest extends org.scalatest.flatspec.AnyFlatSpec {
         |   "checksum": "someChecksumValue"
         |}""".stripMargin
     val scoutAM = ScoutAM(
-      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password"),
+      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot"),
       new TestHttpService("", responseForFileDetails, 200, 200)
     )
     val details = scoutAM.getFileDetails(List("/tmp/file1", "/tmp/file2"))
@@ -56,7 +56,7 @@ class ScoutAMTest extends org.scalatest.flatspec.AnyFlatSpec {
 
   "Authenticate" should "error when authentication is unsuccessful" in {
     val scoutAM = ScoutAM(
-      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password"),
+      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot"),
       new TestHttpService("", """{"status": "does-not-matter"}""", 401, 200)
     )
     val ex = intercept[Exception] {
@@ -67,7 +67,7 @@ class ScoutAMTest extends org.scalatest.flatspec.AnyFlatSpec {
 
   "Authenticate" should "error when authentication response cannot be parsed" in {
     val scoutAM = ScoutAM(
-      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password"),
+      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot"),
       new TestHttpService("""{"this": "cannot-be-parsed"}""", "", 200, 200)
     )
     val ex = intercept[Exception] {
@@ -78,7 +78,16 @@ class ScoutAMTest extends org.scalatest.flatspec.AnyFlatSpec {
 
   "Get file details" should "return an empty map when unable to retrieve file details" in {
     val scoutAM = ScoutAM(
-      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password"),
+      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot"),
+      new TestHttpService("", """{"error":"Unauthorized"}""", 200, 401)
+    )
+    val details = scoutAM.getFileDetails(List("/tmp/file1", "/tmp/file2"))
+    details shouldBe empty
+  }
+
+  "Get file details" should "return an empty map when the mount root is incorrect" in {
+    val scoutAM = ScoutAM(
+      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "incorrectMountRoot"),
       new TestHttpService("", """{"error":"Unauthorized"}""", 200, 401)
     )
     val details = scoutAM.getFileDetails(List("/tmp/file1", "/tmp/file2"))
@@ -97,7 +106,7 @@ class ScoutAMTest extends org.scalatest.flatspec.AnyFlatSpec {
         |  "checksum": null
         |}""".stripMargin
     val scoutAM = ScoutAM(
-      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password"),
+      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot"),
       new TestHttpService("", responseForFileDetails, 200, 200)
     )
     val details = scoutAM.getFileDetails(List("/tmp/file1", "/tmp/file2"))
@@ -117,7 +126,7 @@ class ScoutAMTest extends org.scalatest.flatspec.AnyFlatSpec {
         |  "checksum": null
         |}""".stripMargin
     val scoutAM = ScoutAM(
-      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password"),
+      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot"),
       new TestHttpService("", responseForFileDetails, 200, 200)
     )
     val details = scoutAM.getFileDetails(List("/tmp/file1", "/tmp/file2"))
@@ -129,8 +138,10 @@ class TestHttpService(authResponse: String = "", fileResponse: String = "", auth
   override def get(request: HttpRequest): HttpResponse[String] = {
     request.uri().toString match {
       case uri if uri.contains("/v1/file") =>
-        val filename = uri.split("path=").last.split("%2F").last
-        if fileStatus == 200 then
+        val parameterValue = uri.split("path=").last
+        val filename = parameterValue.split("%2F").last
+        if !parameterValue.startsWith("mountRoot") then TestHttpResponse(404, "")
+        else if fileStatus == 200 then
           if fileResponse.nonEmpty then new TestHttpResponse(fileStatus, fileResponse)
           else
             new TestHttpResponse(

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/TestUtils.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/TestUtils.scala
@@ -55,7 +55,8 @@ object TestUtils:
         val ccConfig = CCConfig("table", dynamoAttributeName, "", Some(URI.create("https://example.com")), repoDir.toString, workDir.toString)
         ccConfig -> Confirmer.ccConfirmer(ocfl(existingRefs, ccConfig))
       else
-        val tcConfig = TCConfig("table", dynamoAttributeName, "", Some(URI.create("https://example.com")), "https://example.com", "user", "password")
+        val tcConfig =
+          TCConfig("table", dynamoAttributeName, "", Some(URI.create("https://example.com")), "https://example.com", "user", "password", "mountRoot")
         tcConfig -> Confirmer.tcConfirmer(scoutAM(existingPaths, tcConfig))
     _ <- Main
       .runConfirmer(


### PR DESCRIPTION
The first thing is that we were calling `getPath` in the CC confirmer which gets the path
from the root of the object path but we need the path from the root of the
repository path to be able to find it. `getStorageRelativePath` does this.

Also, in the TC confirmer, we're trying to use the path without prepending the mount point path.
I've added in an environment variable for this which is already set on the servers
