### PR TITLE
DR2-2938 Fix vulnerabilities in the mock tape api image

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -186,7 +186,8 @@ lazy val mockTapeApi = (project in file("custodial-copy-mock-tape-api"))
     ),
 
     dockerCommands := Seq(
-      Cmd("FROM", "python:3.14"),
+      Cmd("FROM", "alpine:latest"),
+      Cmd("RUN", "apk add --no-cache python3"),
       Cmd("WORKDIR", "/app"),
       Cmd("COPY", "app/mock_tape_api.py", "/app/mock_tape_api.py"),
       ExecCmd("CMD", "python", "mock_tape_api.py")


### PR DESCRIPTION
This was using the python:3.14 base image which has a lot of vulnerabilities.

This can be fixed by using the base alpine image and installing python.
