### PR TITLE
Logging changes

### DIFF
--- a/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Main.scala
+++ b/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Main.scala
@@ -107,7 +107,7 @@ object Main extends IOApp {
                     case e                                  => IO.raiseError(e)
                   } >>
                   sqsClient.deleteMessage(config.sqsUrl, sqsMessage.receiptHandle).void
-
+              case Result.Failure(err) if err.getMessage.contains("Invalid payload") => logger.error(err.getMessage)
               case Result.Failure(err) => logger.info(err.getMessage)
           }
         } yield ()

--- a/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Main.scala
+++ b/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Main.scala
@@ -108,7 +108,7 @@ object Main extends IOApp {
                   } >>
                   sqsClient.deleteMessage(config.sqsUrl, sqsMessage.receiptHandle).void
               case Result.Failure(err) if err.getMessage.contains("Invalid payload") => logger.error(err.getMessage)
-              case Result.Failure(err) => logger.info(err.getMessage)
+              case Result.Failure(err)                                               => logger.info(err.getMessage)
           }
         } yield ()
       }

--- a/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Main.scala
+++ b/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Main.scala
@@ -76,7 +76,7 @@ object Main extends IOApp {
         for {
           logger <- Slf4jLogger.create[IO]
           messages <- aggregateMessages[IO, OutputQueueMessage](sqsClient, config.sqsUrl)
-          _ <- IO.whenA(messages.nonEmpty)(logger.info(s"Processing message refs ${messages.map(_.message.payload.toString).mkString(",")}"))
+          _ <- IO.whenA(messages.nonEmpty)(logger.info(s"Processing ${messages.length} messages"))
           _ <- messages.parTraverse { sqsMessage =>
             val message = sqsMessage.message
             val payload = message.payload
@@ -108,7 +108,7 @@ object Main extends IOApp {
                   } >>
                   sqsClient.deleteMessage(config.sqsUrl, sqsMessage.receiptHandle).void
 
-              case Result.Failure(err) => logError[IO](err)
+              case Result.Failure(err) => logger.info(err.getMessage)
           }
         } yield ()
       }


### PR DESCRIPTION
We can get up to 50 messages at a time so printing them all is quite noisy so we'll just print how many there are.

The `Failure` case should mostly be when we haven't found the file in CC or on tape so we don't want that as a full stack trace error
There's the slight chance we'll get the "Invalid payload type for CC/TC" errors as info messages but I can live with that.
