### PR TITLE
DR2-2946 Semaphore for each id

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,9 @@ SQS queue.
 #### Parallel processing
 
 Each message is processed in parallel, except for writing to the OCFL repository.
-The OCFL library will throw an exception if you try to write to the same object at the same time so there is a single
-semaphore to prevent two fibers writing at the same time.
+The OCFL library will throw an exception if you try to write to the same object at the same time. 
+To prevent this, a semaphore with a single permit is created for each IO we have messages for. 
+This allows us to process individual objects in parallel but OCFL operations on any given object will be processed in sequence.   
 All other processes such as fetching the data from Preservica and deleting the SQS messages are processed in parallel.
 All non-deleted messages are processed (in parallel first) and then the deleted messages to prevent unwanted behaviour,
 like a

--- a/custodial-copy-backend/src/main/resources/application.conf
+++ b/custodial-copy-backend/src/main/resources/application.conf
@@ -10,3 +10,5 @@ queue-timeout=${?QUEUE_TIMEOUT}
 queue-timeout=1h
 potential-ic-db-path=${?IC_DATABASE_PATH}
 files-cache-dir=${FILES_CACHE_DIR}
+max-messages=${?MAX_MESSAGES}
+max-messages=100

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Main.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Main.scala
@@ -1,7 +1,7 @@
 package uk.gov.nationalarchives.custodialcopy
 
 import cats.effect.*
-import cats.effect.std.Semaphore
+import cats.effect.std.{MapRef, Semaphore}
 import cats.implicits.*
 import fs2.Stream
 import io.circe.{Decoder, HCursor}
@@ -19,6 +19,8 @@ import uk.gov.nationalarchives.utils.Utils.*
 import java.net.URI
 import java.nio.file
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import scala.jdk.CollectionConverters.*
 import scala.concurrent.duration.{Duration, DurationInt}
 
 object Main extends IOApp {
@@ -34,7 +36,8 @@ object Main extends IOApp {
       topicArn: String,
       queueTimeout: Duration,
       potentialIcDbPath: Option[String],
-      filesCacheDir: String
+      filesCacheDir: String,
+      maxMessages: Int
   ) derives ConfigReader
 
   given Decoder[ReceivedSnsMessage] = (c: HCursor) =>
@@ -60,28 +63,44 @@ object Main extends IOApp {
   private case class DedupedMessages(removedMessages: List[MessageResponse[ReceivedSnsMessage]], retainedMessages: List[MessageResponse[ReceivedSnsMessage]])
 
   override def run(args: List[String]): IO[ExitCode] =
+    val underlyingMap = ConcurrentHashMap[UUID, Semaphore[IO]]()
+    val semaphoreMap: MapRef[IO, UUID, Option[Semaphore[IO]]] = MapRef.fromConcurrentHashMap[IO, UUID, Semaphore[IO]](underlyingMap)
+
+    def semaphoreRelease() =
+      underlyingMap
+        .keySet()
+        .asScala
+        .toList
+        .traverse(id => semaphoreMap(id).get)
+        .flatMap(_.flatten.traverse(_.release))
+        .void
     for {
       config <- ConfigSource.default.loadF[IO, Config]()
       client <- Fs2Client.entityClient(
         config.preservicaSecretName,
         potentialProxyUrl = config.potentialProxyUrl
       )
-      semaphore <- Semaphore[IO](1)
-      service <- OcflService(config, semaphore)
+
+      service <- OcflService(config, semaphoreMap)
       sqs = sqsClient[IO](config.potentialProxyUrl)
       sns = DASNSClient[IO]()
       processor <- Processor(config, sqs, service, client, sns)
       _ <- {
         Stream.fixedRateStartImmediately[IO](10.seconds) >>
-          runCustodialCopy(sqs, config, processor)
-            .map(outcomes => if outcomes.exists(_.isError) then semaphore.release else IO.unit)
-            .handleErrorWith(err => Stream.eval(semaphore.release >> logError(err)))
+          runCustodialCopy(sqs, config, processor, semaphoreMap)
+            .map(outcomes => if outcomes.exists(_.isError) then semaphoreRelease() else IO.unit)
+            .handleErrorWith(err => Stream.eval(semaphoreRelease() >> logError(err)))
       }.compile.drain
     } yield ExitCode.Success
 
-  def runCustodialCopy(sqs: DASQSClient[IO], config: Config, processor: Processor): Stream[IO, List[Result]] =
+  def runCustodialCopy(
+      sqs: DASQSClient[IO],
+      config: Config,
+      processor: Processor,
+      semaphoreMap: MapRef[IO, UUID, Option[Semaphore[IO]]]
+  ): Stream[IO, List[Result]] =
     Stream
-      .eval(aggregateMessages(sqs, config.sqsQueueUrl))
+      .eval(aggregateMessages(sqs, config.sqsQueueUrl, config.maxMessages))
       .filter(messageResponses => messageResponses.nonEmpty)
       .evalMap { messageResponses =>
         messageResponses
@@ -90,13 +109,18 @@ object Main extends IOApp {
           .parTraverse { case (potentialMessageGroupId, responses) =>
             potentialMessageGroupId match
               case Some(groupId) =>
-                processMessages(processor, responses, groupId, config)
+                val groupUuid = UUID.fromString(groupId)
+                for
+                  semaphore <- Semaphore[IO](1)
+                  _ <- semaphoreMap(groupUuid).update(_ => semaphore.some)
+                  res <- processMessages(processor, responses, groupUuid, config)
+                yield res
               case None => IO.raiseError(new Exception("Message Group ID is missing"))
           }
           .map(_.flatten)
       }
 
-  private def processMessages(processor: Processor, responses: List[MessageResponse[ReceivedSnsMessage]], groupId: String, config: Config) = {
+  private def processMessages(processor: Processor, responses: List[MessageResponse[ReceivedSnsMessage]], groupId: UUID, config: Config) = {
     for {
       logger <- Slf4jLogger.create[IO]
       _ <- logger.info(s"Processing ${responses.length} messages")
@@ -111,7 +135,7 @@ object Main extends IOApp {
       results <- dedupedMessages.retainedMessages.traverse(processor.process)
       removedResults = dedupedMessages.removedMessages.map(r => Success(r.message.ref, Nil, 0L, Nil, 0L))
 
-      _ <- processor.commitStagedChanges(UUID.fromString(groupId))
+      _ <- processor.commitStagedChanges(groupId)
       _ <- logger.info(s"${results.count(_.isSuccess)} out of ${results.length} unique messages processed successfully")
       _ <- logger.info(s"${results.count(_.isError)} out of ${results.length} unique messages failed")
 

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/OcflService.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/OcflService.scala
@@ -1,7 +1,7 @@
 package uk.gov.nationalarchives.custodialcopy
 
 import cats.effect.IO
-import cats.effect.std.Semaphore
+import cats.effect.std.{MapRef, Semaphore}
 import cats.syntax.all.*
 import io.ocfl.api.exception.{CorruptObjectException, NotFoundException}
 import io.ocfl.api.model.DigestAlgorithm
@@ -23,24 +23,28 @@ import java.util.UUID
 import scala.jdk.CollectionConverters.*
 import scala.jdk.FunctionConverters.*
 
-class OcflService(ocflRepository: MutableOcflRepository, semaphore: Semaphore[IO]) {
+class OcflService(ocflRepository: MutableOcflRepository, semaphoreMap: MapRef[IO, UUID, Option[Semaphore[IO]]]) {
 
   given Logger[IO] = Slf4jLogger.getLogger[IO]
 
-  private def logErrorAndRelease: PartialFunction[Throwable, IO[Unit]] =
-    case err => Logger[IO].error(err)(err.getMessage) >> semaphore.release
+  private def logErrorAndRelease(id: UUID): PartialFunction[Throwable, IO[Unit]] =
+    case err => Logger[IO].error(err)(err.getMessage) >> semaphoreRelease(id)
+
+  private def semaphoreAcquire(id: UUID): IO[Unit] = semaphoreMap(id).get.flatMap(_.map(_.acquire).getOrElse(IO.unit))
+
+  private def semaphoreRelease(id: UUID): IO[Unit] = semaphoreMap(id).get.flatMap(_.map(_.release).getOrElse(IO.unit))
 
   def commitStagedChanges(id: UUID): IO[Unit] =
-    semaphore.acquire >> IO.whenA(ocflRepository.hasStagedChanges(id.toString)) {
+    semaphoreAcquire(id) >> IO.whenA(ocflRepository.hasStagedChanges(id.toString)) {
       IO.blocking[Unit] {
         ocflRepository.commitStagedChanges(id.toString, null)
-      }.onError(logErrorAndRelease)
-    } >> semaphore.release
+      }.onError(logErrorAndRelease(id))
+    } >> semaphoreRelease(id)
 
-  def createObjects(paths: List[FileDownloadInfo]): IO[Unit] = paths
+  def createObjects(id: UUID, paths: List[FileDownloadInfo]): IO[Unit] = paths
     .traverse { path =>
       IO.whenA(path.sourceNioFilePath.isDefined) {
-        semaphore.acquire >> IO.blocking {
+        semaphoreAcquire(id) >> IO.blocking {
           ocflRepository.stageChanges(
             path.id.toHeadVersion,
             null,
@@ -54,13 +58,13 @@ class OcflService(ocflRepository: MutableOcflRepository, semaphore: Semaphore[IO
               ()
             }.asJava
           )
-        } >> semaphore.release
+        } >> semaphoreRelease(id)
       }
     }
-    .onError(logErrorAndRelease)
+    .onError(logErrorAndRelease(id))
     .void
 
-  def deleteObjects(ioId: UUID, destinationFilePaths: List[String]): IO[Unit] = semaphore.acquire >> IO
+  def deleteObjects(ioId: UUID, destinationFilePaths: List[String]): IO[Unit] = semaphoreAcquire(ioId) >> IO
     .blocking {
       ocflRepository.stageChanges(
         ioId.toHeadVersion,
@@ -68,7 +72,7 @@ class OcflService(ocflRepository: MutableOcflRepository, semaphore: Semaphore[IO
         { (updater: OcflObjectUpdater) => destinationFilePaths.foreach { path => updater.removeFile(path) } }.asJava
       )
     }
-    .onError(logErrorAndRelease) >> semaphore.release
+    .onError(logErrorAndRelease(ioId)) >> semaphoreRelease(ioId)
 
   def getMissingAndChangedObjects(
       objects: List[CustodialCopyObject]
@@ -114,7 +118,7 @@ class OcflService(ocflRepository: MutableOcflRepository, semaphore: Semaphore[IO
     }
 
   private def purgeObject(objectId: UUID) = {
-    semaphore.acquire >> IO.blocking(ocflRepository.purgeObject(objectId.toString)).onError(logErrorAndRelease) >> semaphore.release
+    semaphoreAcquire(objectId) >> IO.blocking(ocflRepository.purgeObject(objectId.toString)).onError(logErrorAndRelease(objectId)) >> semaphoreRelease(objectId)
   }
 
   private def isChecksumUnchanged(fixitiesMap: Map[DigestAlgorithm, String], checksums: List[Checksum]): IO[Boolean] = {
@@ -163,7 +167,7 @@ class OcflService(ocflRepository: MutableOcflRepository, semaphore: Semaphore[IO
 }
 object OcflService {
 
-  def apply(config: Config, semaphore: Semaphore[IO]): IO[OcflService] = IO {
+  def apply(config: Config, semaphoreMap: MapRef[IO, UUID, Option[Semaphore[IO]]]): IO[OcflService] = IO {
     val repoDir = Paths.get(config.repoDir)
     val workDir =
       Paths.get(
@@ -185,7 +189,7 @@ object OcflService {
       .prettyPrintJson()
       .workDir(workDir)
       .buildMutable()
-    new OcflService(repo, semaphore)
+    new OcflService(repo, semaphoreMap)
   }
   case class MissingAndChangedObjects(
       missingObjects: List[CustodialCopyObject],

--- a/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
+++ b/custodial-copy-backend/src/main/scala/uk/gov/nationalarchives/custodialcopy/Processor.scala
@@ -359,7 +359,8 @@ class Processor(
   }
 
   private def processNonDeletedMessages(messageResponse: MessageResponse[ReceivedSnsMessage]): IO[ProcessorOutput] =
-    val downloadFile = download(_, UUID.fromString(messageResponse.messageGroupId.get))
+    val ioId = UUID.fromString(messageResponse.messageGroupId.get)
+    val downloadFile = download(_, ioId)
     for {
       logger <- Slf4jLogger.create[IO]
       custodialCopyObjects <- toCustodialCopyObject(messageResponse.message)
@@ -406,9 +407,9 @@ class Processor(
         )
       }
 
-      _ <- ocflService.createObjects(missingObjectsPaths)
+      _ <- ocflService.createObjects(ioId, missingObjectsPaths)
       _ <- logger.info(s"${missingObjectsPaths.length} objects created")
-      _ <- ocflService.createObjects(changedObjectsPaths)
+      _ <- ocflService.createObjects(ioId, changedObjectsPaths)
       _ <- logger.info(s"${changedObjectsPaths.length} objects updated")
 
       _ <- allObjectPaths.flatMap(_.sourceNioFilePath).parTraverse(deleteObjectPath)

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/MainTest.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/MainTest.scala
@@ -1,7 +1,7 @@
 package uk.gov.nationalarchives.custodialcopy
 
 import cats.effect.IO
-import cats.effect.std.Semaphore
+import cats.effect.std.{MapRef, Semaphore}
 import cats.effect.unsafe.implicits.global
 import io.circe.Decoder
 import io.ocfl.api.MutableOcflRepository
@@ -33,6 +33,7 @@ import java.nio.file
 import java.nio.file.{Files, Path, Paths}
 import java.time.{LocalDate, LocalDateTime}
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import scala.jdk.CollectionConverters.*
 import scala.concurrent.duration.*
 import scala.xml.Utility.trim
@@ -57,7 +58,10 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues with Befo
       sqsClient: DASQSClient[IO],
       config: Config,
       processor: Processor
-  ): List[Result] = Main.runCustodialCopy(sqsClient, config, processor).compile.toList.unsafeRunSync().flatten
+  ): List[Result] = {
+    val mapRef = MapRef.fromConcurrentHashMap[IO, UUID, Semaphore[IO]](ConcurrentHashMap[UUID, Semaphore[IO]]())
+    Main.runCustodialCopy(sqsClient, config, processor, mapRef).compile.toList.unsafeRunSync().flatten
+  }
 
   private val exampleUrl = "https://example.com"
 
@@ -252,7 +256,7 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues with Befo
     Files.write(tempFile, "test".getBytes)
     val destinationPath = s"${utils.ioId}/Preservation_1/${utils.coId1}/original/g1/90dfb573-7419-4e89-8558-6cfa29f8fb16.testExt2"
     (for
-      _ <- utils.ocflService.createObjects(List(FileDownloadInfo(utils.ioId, Option(tempFile), destinationPath)))
+      _ <- utils.ocflService.createObjects(utils.ioId, List(FileDownloadInfo(utils.ioId, Option(tempFile), destinationPath)))
       _ <- utils.ocflService.commitStagedChanges(utils.ioId)
     yield ()).unsafeRunSync()
 
@@ -801,8 +805,9 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues with Befo
 
     val repo = mock[MutableOcflRepository]
     when(repo.getObject(any[ObjectVersionId])).thenThrow(new RuntimeException("Unexpected Exception"))
-    val semaphore: Semaphore[IO] = Semaphore[IO](1).unsafeRunSync()
-    val ocflService = new OcflService(repo, semaphore)
+    val underlyingMap: ConcurrentHashMap[UUID, Semaphore[IO]] = ConcurrentHashMap[UUID, Semaphore[IO]]()
+    val semaphoreMap: MapRef[IO, UUID, Option[Semaphore[IO]]] = MapRef.fromConcurrentHashMap(underlyingMap)
+    val ocflService = new OcflService(repo, semaphoreMap)
     val processor =
       new Processor(
         utils.config,
@@ -916,7 +921,7 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues with Befo
     val messageIdOne = Option(UUID.randomUUID.toString)
     val messageIdTwo = Option(UUID.randomUUID.toString)
 
-    val config: Config = Config("", "https://queue", "", "", "", None, "", "", 2.seconds, Some(databaseName), "")
+    val config: Config = Config("", "https://queue", "", "", "", None, "", "", 2.seconds, Some(databaseName), "", 50)
     val sqsClient = mock[DASQSClient[IO]]
 
     val processor = new TestProcessor(
@@ -965,7 +970,7 @@ class MainTest extends AnyFlatSpec with MockitoSugar with EitherValues with Befo
     val delayedId = UUID.randomUUID
     val id = UUID.randomUUID
     val messageId = Option(UUID.randomUUID.toString)
-    val config: Config = Config("", "https://queue", "", "", "", None, "", "", 2.seconds, Some(databaseName), "")
+    val config: Config = Config("", "https://queue", "", "", "", None, "", "", 2.seconds, Some(databaseName), "", 1)
     val sqsClient = mock[DASQSClient[IO]]
 
     val processor = new TestProcessor(

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/OcflServiceTest.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/OcflServiceTest.scala
@@ -1,7 +1,7 @@
 package uk.gov.nationalarchives.custodialcopy
 
 import cats.effect.IO
-import cats.effect.std.Semaphore
+import cats.effect.std.{MapRef, Semaphore}
 import cats.effect.unsafe.implicits.global
 import io.ocfl.api.exception.{CorruptObjectException, NotFoundException}
 import io.ocfl.api.model.*
@@ -21,6 +21,7 @@ import uk.gov.nationalarchives.utils.testOcflFileRetriever
 
 import java.nio.file.{Files, Path}
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import java.util.function.Consumer
 import scala.jdk.CollectionConverters.*
 
@@ -33,7 +34,8 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
   val checksums = List(md5, sha256)
   private val destinationPath = "destinationPath"
   private val entity = mock[Entity]
-  val semaphore: Semaphore[IO] = Semaphore[IO](1).unsafeRunSync()
+  val underlyingMap: ConcurrentHashMap[UUID, Semaphore[IO]] = ConcurrentHashMap[UUID, Semaphore[IO]]()
+  val semaphoreMap: MapRef[IO, UUID, Option[Semaphore[IO]]] = MapRef.fromConcurrentHashMap(underlyingMap)
 
   def mockGetObjectResponse(
       ocflRepository: MutableOcflRepository,
@@ -57,7 +59,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
     val ocflRepository = mock[MutableOcflRepository]
     when(ocflRepository.getObject(any[ObjectVersionId])).thenThrow(new NotFoundException)
 
-    val service = new OcflService(ocflRepository, semaphore)
+    val service = new OcflService(ocflRepository, semaphoreMap)
     val fileObjectThatShouldBeMissing =
       FileObject(id, name, checksums, url, destinationPath, UUID.randomUUID.toString)
 
@@ -77,7 +79,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
       val ocflRepository = mock[MutableOcflRepository]
       mockGetObjectResponse(ocflRepository, id, Option(sha256.fingerprint), destinationPath)
 
-      val service = new OcflService(ocflRepository, semaphore)
+      val service = new OcflService(ocflRepository, semaphoreMap)
       val fileObjectThatShouldBeMissing =
         FileObject(id, name, checksums, url, "nonExistingDestinationPath", UUID.randomUUID.toString)
 
@@ -97,7 +99,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
       val ocflRepository = mock[MutableOcflRepository]
       mockGetObjectResponse(ocflRepository, id, Option(sha256.fingerprint), destinationPath)
 
-      val service = new OcflService(ocflRepository, semaphore)
+      val service = new OcflService(ocflRepository, semaphoreMap)
 
       val missingAndChangedObjects =
         service
@@ -116,7 +118,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
       val ocflRepository = mock[MutableOcflRepository]
       mockGetObjectResponse(ocflRepository, id, Option(sha256.fingerprint), destinationPath)
 
-      val service = new OcflService(ocflRepository, semaphore)
+      val service = new OcflService(ocflRepository, semaphoreMap)
       val fileObjectThatShouldHaveChangedChecksum =
         FileObject(id, name, List(Checksum("SHA256", "anotherChecksum")), url, destinationPath, UUID.randomUUID.toString)
 
@@ -134,7 +136,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
     val ocflRepository = mock[MutableOcflRepository]
     when(ocflRepository.getObject(any[ObjectVersionId])).thenThrow(new RuntimeException("unexpected Exception"))
 
-    val service = new OcflService(ocflRepository, semaphore)
+    val service = new OcflService(ocflRepository, semaphoreMap)
     val fileObjectThatShouldHaveChangedChecksum =
       FileObject(id, name, checksums, url, destinationPath, UUID.randomUUID.toString)
 
@@ -154,7 +156,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
     when(ocflRepository.getObject(any[ObjectVersionId])).thenThrow(new CorruptObjectException())
     doNothing().when(ocflRepository).purgeObject(objectIdCaptor.capture())
 
-    val service = new OcflService(ocflRepository, semaphore)
+    val service = new OcflService(ocflRepository, semaphoreMap)
     val fileObjectThatShouldHaveChangedChecksum =
       FileObject(id, name, checksums, url, destinationPath, UUID.randomUUID.toString)
 
@@ -173,7 +175,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
     val ocflRepository = mock[MutableOcflRepository]
     mockGetObjectResponse(ocflRepository, id, Option(sha256.fingerprint), destinationPath)
 
-    val service = new OcflService(ocflRepository, semaphore)
+    val service = new OcflService(ocflRepository, semaphoreMap)
 
     val error =
       service
@@ -195,7 +197,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
     val ocflRepository = mock[MutableOcflRepository]
     mockGetObjectResponse(ocflRepository, id, None, destinationPath)
 
-    val service = new OcflService(ocflRepository, semaphore)
+    val service = new OcflService(ocflRepository, semaphoreMap)
 
     val error =
       service
@@ -217,7 +219,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
     val ocflRepository = mock[MutableOcflRepository]
     mockGetObjectResponse(ocflRepository, id, None, destinationPath)
 
-    val service = new OcflService(ocflRepository, semaphore)
+    val service = new OcflService(ocflRepository, semaphoreMap)
 
     val error =
       service
@@ -236,9 +238,9 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
 
   "createObjects" should "not create an object if the file path doesn't exist" in {
     val ocflRepository = mock[MutableOcflRepository]
-    val service = new OcflService(ocflRepository, semaphore)
-
-    service.createObjects(List(FileDownloadInfo(UUID.randomUUID, None, "destination"))).unsafeRunSync()
+    val service = new OcflService(ocflRepository, semaphoreMap)
+    val id = UUID.randomUUID
+    service.createObjects(id, List(FileDownloadInfo(id, None, "destination"))).unsafeRunSync()
 
     verifyNoInteractions(ocflRepository)
   }
@@ -261,9 +263,9 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
         consumer.accept(updater)
         ObjectVersionId.head(id.toString)
       }
-    val service = new OcflService(ocflRepository, semaphore)
+    val service = new OcflService(ocflRepository, semaphoreMap)
 
-    service.createObjects(List(FileDownloadInfo(id, Option(inputPath), destinationPath))).unsafeRunSync()
+    service.createObjects(id, List(FileDownloadInfo(id, Option(inputPath), destinationPath))).unsafeRunSync()
 
     UUID.fromString(objectVersionCaptor.getValue.getObjectId) should equal(id)
     verify(updater, times(1)).addPath(
@@ -283,7 +285,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
     val ocflRepository = mock[MutableOcflRepository]
     mockGetObjectResponse(ocflRepository, id, Option(sha256.fingerprint), destinationPath)
 
-    val service = new OcflService(ocflRepository, semaphore)
+    val service = new OcflService(ocflRepository, semaphoreMap)
 
     val filePathsOnAnObject = service.getAllFilePathsOnAnObject(id).unsafeRunSync()
     filePathsOnAnObject.foreach(_ should equal(destinationPath))
@@ -294,7 +296,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
     val ocflRepository = mock[MutableOcflRepository]
     when(ocflRepository.getObject(any[ObjectVersionId])).thenThrow(new RuntimeException("unexpected Exception"))
 
-    val service = new OcflService(ocflRepository, semaphore)
+    val service = new OcflService(ocflRepository, semaphoreMap)
 
     val ex = intercept[Exception] {
       service.getAllFilePathsOnAnObject(id).unsafeRunSync()
@@ -312,7 +314,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
     when(ocflRepository.getObject(any[ObjectVersionId])).thenThrow(new CorruptObjectException())
     doNothing().when(ocflRepository).purgeObject(objectIdCaptor.capture())
 
-    val service = new OcflService(ocflRepository, semaphore)
+    val service = new OcflService(ocflRepository, semaphoreMap)
 
     val ex = intercept[Exception] {
       service.getAllFilePathsOnAnObject(id).unsafeRunSync()
@@ -337,7 +339,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
         consumer.accept(updater)
         ObjectVersionId.head(id.toString)
       }
-    val service = new OcflService(ocflRepository, semaphore)
+    val service = new OcflService(ocflRepository, semaphoreMap)
 
     service.deleteObjects(id, List(destinationPath, "destinationPath2")).unsafeRunSync()
 
@@ -367,7 +369,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
 
     when(ocflRepository.hasStagedChanges(id.toString)).thenReturn(true)
 
-    val service = new OcflService(ocflRepository, semaphore)
+    val service = new OcflService(ocflRepository, semaphoreMap)
 
     service.commitStagedChanges(id).unsafeRunSync()
 
@@ -381,7 +383,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
     val ocflRepository = mock[MutableOcflRepository]
     when(ocflRepository.hasStagedChanges(id.toString)).thenReturn(false)
 
-    new OcflService(ocflRepository, semaphore).commitStagedChanges(id).unsafeRunSync()
+    new OcflService(ocflRepository, semaphoreMap).commitStagedChanges(id).unsafeRunSync()
 
     verify(ocflRepository, times(0)).getObject(any[ObjectVersionId])
     verify(ocflRepository, times(0)).commitStagedChanges(any[String], any[VersionInfo])
@@ -392,7 +394,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
     val ocflRepository = mock[MutableOcflRepository]
     mockGetObjectResponse(ocflRepository, id, Option(sha256.fingerprint), destinationPath)
 
-    val ocflService = new OcflService(ocflRepository, semaphore)
+    val ocflService = new OcflService(ocflRepository, semaphoreMap)
 
     val fileObject = FileObject(UUID.randomUUID(), "", List(Checksum("SHA256", sha256.fingerprint)), "", destinationPath, "")
 
@@ -404,7 +406,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
     val ocflRepository = mock[MutableOcflRepository]
     mockGetObjectResponse(ocflRepository, id, Option(sha256.fingerprint), destinationPath)
 
-    val ocflService = new OcflService(ocflRepository, semaphore)
+    val ocflService = new OcflService(ocflRepository, semaphoreMap)
 
     val fileObject = FileObject(UUID.randomUUID(), "", List(Checksum("SHA256", "anotherChecksum")), "", destinationPath, "")
 
@@ -416,7 +418,7 @@ class OcflServiceTest extends AnyFlatSpec with MockitoSugar with TableDrivenProp
     val ocflRepository = mock[MutableOcflRepository]
     mockGetObjectResponse(ocflRepository, id, Option(sha256.fingerprint), destinationPath)
 
-    val ocflService = new OcflService(ocflRepository, semaphore)
+    val ocflService = new OcflService(ocflRepository, semaphoreMap)
 
     val fileObject = FileObject(UUID.randomUUID(), "", List(Checksum("SHA256", sha256.fingerprint)), "", "/test/path", "")
 

--- a/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/testUtils/ExternalServicesTestUtils.scala
+++ b/custodial-copy-backend/src/test/scala/uk/gov/nationalarchives/custodialcopy/testUtils/ExternalServicesTestUtils.scala
@@ -1,7 +1,7 @@
 package uk.gov.nationalarchives.custodialcopy.testUtils
 
 import cats.effect.IO
-import cats.effect.std.Semaphore
+import cats.effect.std.{MapRef, Semaphore}
 import cats.effect.unsafe.implicits.global
 import fs2.Stream
 import io.circe.{Decoder, Encoder}
@@ -53,6 +53,7 @@ import scala.jdk.FunctionConverters.*
 import java.net.URI
 import java.nio.file.{Files, Path, Paths}
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import scala.concurrent.duration.Duration
 import scala.jdk.CollectionConverters.ListHasAsScala
 import scala.util.{Failure, Success, Try}
@@ -209,9 +210,10 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
     Files.createDirectories(Paths.get(path.toString, id.toString))
     val fullSourceFilePath = Paths.get(path.toString, sourceFilePath)
     Files.write(fullSourceFilePath, bodyAsString.getBytes)
-    val semaphore: Semaphore[IO] = Semaphore[IO](1).unsafeRunSync()
-    new OcflService(repo, semaphore)
-      .createObjects(List(FileDownloadInfo(id, Option(fullSourceFilePath), destinationPath)))
+    val underlyingMap: ConcurrentHashMap[UUID, Semaphore[IO]] = ConcurrentHashMap[UUID, Semaphore[IO]]()
+    val semaphoreMap: MapRef[IO, UUID, Option[Semaphore[IO]]] = MapRef.fromConcurrentHashMap(underlyingMap)
+    new OcflService(repo, semaphoreMap)
+      .createObjects(id, List(FileDownloadInfo(id, Option(fullSourceFilePath), destinationPath)))
       .unsafeRunSync()
   }
 
@@ -303,7 +305,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
         s"/${Files.writeString(Files.createTempFile(cacheDir, "file", ""), "file content").toString}"
       else ""
 
-    val config: Config = Config("", "", repoDir.toString, workDir, downloadDir, None, "", "", Duration("1s"), potentialDbName, cacheDir.toString)
+    val config: Config = Config("", "", repoDir.toString, workDir, downloadDir, None, "", "", Duration("1s"), potentialDbName, cacheDir.toString, 50)
 
     val bitstreamInfoResponsesWithSameName: Seq[BitStreamInfo] = bitstreamInfo1Responses.flatMap { bitstreamInfo1Response =>
       bitstreamInfo2Responses.filter { bitstreamInfo2Response =>
@@ -419,8 +421,9 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
       .foreach { case (data, name, destinationPath) =>
         addFileToRepo(ioId, repo, data, s"$ioId/$name", destinationPath)
       }
-    val semaphore: Semaphore[IO] = Semaphore[IO](1).unsafeRunSync()
-    val ocflService = new OcflService(repo, semaphore)
+    val underlyingMap: ConcurrentHashMap[UUID, Semaphore[IO]] = ConcurrentHashMap[UUID, Semaphore[IO]]()
+    val semaphoreMap: MapRef[IO, UUID, Option[Semaphore[IO]]] = MapRef.fromConcurrentHashMap(underlyingMap)
+    val ocflService = new OcflService(repo, semaphoreMap)
     val xmlValidator: ValidateXmlAgainstXsd[IO] = ValidateXmlAgainstXsd[IO](XipXsdSchemaV7)
     val processor = new Processor(config, sqsClient, ocflService, preservicaClient, xmlValidator, snsClient)
 
@@ -474,7 +477,8 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
         "topicArn",
         Duration("1s"),
         if cacheDir then Some(databaseName) else None,
-        filesCacheDir.toString
+        filesCacheDir.toString,
+        1
       )
     val ioId: UUID = UUID.randomUUID()
     val coId: UUID = UUID.randomUUID()
@@ -496,7 +500,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
       MessageResponse[ReceivedSnsMessage]("receiptHandle1", Option(ioMessage.ref.toString), ioMessage)
 
     val coMessageResponse: MessageResponse[ReceivedSnsMessage] =
-      MessageResponse[ReceivedSnsMessage]("receiptHandle2", Option(coMessage.ref.toString), coMessage)
+      MessageResponse[ReceivedSnsMessage]("receiptHandle2", Option(ioMessage.ref.toString), coMessage)
 
     private val potentialParentRef = if parentRefExists then Some(ioId) else None
 
@@ -565,6 +569,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
     private val repTypeCaptor: ArgumentCaptor[RepresentationType] = ArgumentCaptor.forClass(classOf[RepresentationType])
     private val repIndexCaptor: ArgumentCaptor[Int] = ArgumentCaptor.forClass(classOf[Int])
 
+    private val idCaptor: ArgumentCaptor[UUID] = ArgumentCaptor.forClass(classOf[UUID])
     private val fileDownloadInfoCaptor: ArgumentCaptor[List[FileDownloadInfo]] =
       ArgumentCaptor.forClass(classOf[List[FileDownloadInfo]])
     private val metadataXmlStringToValidate: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
@@ -638,7 +643,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
               }
             )
           )
-      when(ocflService.createObjects(any[List[FileDownloadInfo]])).thenReturn(IO.unit)
+      when(ocflService.createObjects(any[UUID], any[List[FileDownloadInfo]])).thenReturn(IO.unit)
       when(ocflService.getAllFilePathsOnAnObject(any[UUID])).thenReturn(IO.pure(pathsOfObjects))
       when(ocflService.deleteObjects(any[UUID], any[List[String]])).thenReturn(IO.unit)
       when(ocflService.commitStagedChanges(commitIdCaptor.capture)).thenReturn(IO.unit)
@@ -757,7 +762,7 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
         droLookupCaptor.capture()
       )
       verify(ocflService, times(createdFileDownloadInfo.length))
-        .createObjects(fileDownloadInfoCaptor.capture())
+        .createObjects(idCaptor.capture(), fileDownloadInfoCaptor.capture())
 
       val numOfTimesToDeleteObjects = if destinationPathsToDelete.nonEmpty then 1 else 0
       verify(ocflService, times(numOfTimesToDeleteObjects))
@@ -800,6 +805,10 @@ object ExternalServicesTestUtils extends MockitoSugar with EitherValues {
         capturedIdWithSourceAndDestPath.potentialIcInfo should equal(expectedIdWithSourceAndDestPath.potentialIcInfo)
 
         File(sourcePathString).exists() should equal(false)
+      }
+
+      idCaptor.getAllValues.asScala.headOption.map { id =>
+        id shouldEqual ioId
       }
       val capturedLookupDestinationPaths = droLookupCaptor.getAllValues.asScala.toList.map(_.map(_.destinationFilePath))
       capturedLookupDestinationPaths should equal(drosToLookup)

--- a/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Main.scala
+++ b/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Main.scala
@@ -75,7 +75,7 @@ object Main extends IOApp {
       .eval {
         for {
           logger <- Slf4jLogger.create[IO]
-          messages <- aggregateMessages[IO, OutputQueueMessage](sqsClient, config.sqsUrl)
+          messages <- aggregateMessages[IO, OutputQueueMessage](sqsClient, config.sqsUrl, config.maxMessages)
           _ <- IO.whenA(messages.nonEmpty)(logger.info(s"Processing message refs ${messages.map(_.message.payload.toString).mkString(",")}"))
           _ <- messages.parTraverse { sqsMessage =>
             val message = sqsMessage.message

--- a/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Models.scala
+++ b/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Models.scala
@@ -27,6 +27,7 @@ sealed trait Config:
   def dynamoAttributeName: String
   def sqsUrl: String
   def proxyUrl: Option[URI]
+  def maxMessages: Int
 
 case class CCConfig(
     dynamoTableName: String,
@@ -34,7 +35,8 @@ case class CCConfig(
     sqsUrl: String,
     proxyUrl: Option[URI],
     ocflRepoDir: String,
-    ocflWorkDir: String
+    ocflWorkDir: String,
+    maxMessages: Int
 ) extends Config derives ConfigReader
 
 case class TCConfig(
@@ -45,7 +47,8 @@ case class TCConfig(
     scoutamBaseUrl: String,
     scoutamUsername: String,
     scoutamPassword: String,
-    mountRoot: String
+    mountRoot: String,
+    maxMessages: Int
 ) extends Config derives ConfigReader
 
 extension (s: String) def toAttributeValue: AttributeValue = AttributeValue.builder.s(s).build

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/ConfirmerTest.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/ConfirmerTest.scala
@@ -7,11 +7,11 @@ import uk.gov.nationalarchives.confirmer.TestUtils.{OcflErrors, ScoutAmErrors}
 
 class ConfirmerTest extends AnyFlatSpec {
   "getConfirmer" should "return correct instance of confirmer based on the config type" in {
-    Confirmer.getConfirmer(CCConfig("table", result_CC.toString, "", null, "", "")).getClass.getDeclaredFields.apply(1).getType.getSimpleName should equal(
+    Confirmer.getConfirmer(CCConfig("table", result_CC.toString, "", null, "", "", 50)).getClass.getDeclaredFields.apply(1).getType.getSimpleName should equal(
       "Ocfl"
     )
     Confirmer
-      .getConfirmer(TCConfig("table", result_TC.toString, "", null, "", "", "", "mountRoot"))
+      .getConfirmer(TCConfig("table", result_TC.toString, "", null, "", "", "", "mountRoot", 50))
       .getClass
       .getDeclaredFields
       .apply(1)
@@ -24,7 +24,7 @@ class ConfirmerTest extends AnyFlatSpec {
   "CC Confirmer getResult" should "return success when the payload and service is valid" in {
     val uuid = java.util.UUID.randomUUID()
     val ccPayload = CCPayload(uuid)
-    val ocfl = TestUtils.ocfl(List(uuid), CCConfig("table", result_CC.toString, "", null, "", ""))
+    val ocfl = TestUtils.ocfl(List(uuid), CCConfig("table", result_CC.toString, "", null, "", "", 50))
     val ccResult = Confirmer.ccConfirmer(ocfl).getResult(ccPayload)
 
     ccResult.isSuccess should be(true)
@@ -37,7 +37,7 @@ class ConfirmerTest extends AnyFlatSpec {
 
   "CC Confirmer getResult" should "return failure when the payload is invalid" in {
     val tcPayload = TCPayload(List("file1.txt", "file2.txt")) // Invalid payload for CC confirmer
-    val ocfl = TestUtils.ocfl(List(java.util.UUID.randomUUID()), CCConfig("table", result_CC.toString, "", null, "", ""))
+    val ocfl = TestUtils.ocfl(List(java.util.UUID.randomUUID()), CCConfig("table", result_CC.toString, "", null, "", "", 50))
     val ccResult = Confirmer.ccConfirmer(ocfl).getResult(tcPayload)
 
     ccResult.isError should be(true)
@@ -51,7 +51,7 @@ class ConfirmerTest extends AnyFlatSpec {
   "CC Confirmer getResult" should "fail if the paths cannot be found" in {
     val uuid = java.util.UUID.randomUUID()
     val ccPayload = CCPayload(uuid)
-    val ocfl = TestUtils.ocfl(List(java.util.UUID.randomUUID()), CCConfig("table", result_CC.toString, "", null, "", ""), OcflErrors(true))
+    val ocfl = TestUtils.ocfl(List(java.util.UUID.randomUUID()), CCConfig("table", result_CC.toString, "", null, "", "", 50), OcflErrors(true))
     val ccResult = Confirmer.ccConfirmer(ocfl).getResult(ccPayload)
 
     ccResult.isError should be(true)
@@ -65,7 +65,7 @@ class ConfirmerTest extends AnyFlatSpec {
   "TC Confirmer getResult" should "return success when the payload and service is valid" in {
     val filePaths = List("file1.txt", "file2.txt")
     val tcPayload = TCPayload(filePaths)
-    val scoutAM = TestUtils.scoutAM(filePaths, TCConfig("table", result_TC.toString, "", null, "", "", "", "mountRoot"))
+    val scoutAM = TestUtils.scoutAM(filePaths, TCConfig("table", result_TC.toString, "", null, "", "", "", "mountRoot", 50))
     val tcResult = Confirmer.tcConfirmer(scoutAM).getResult(tcPayload)
 
     tcResult.isSuccess should be(true)
@@ -79,7 +79,7 @@ class ConfirmerTest extends AnyFlatSpec {
 
   "TC Confirmer getResult" should "return failure when the payload is invalid" in {
     val ccPayload = CCPayload(java.util.UUID.randomUUID()) // Invalid payload for TC confirmer
-    val scountAM = TestUtils.scoutAM(List("file1.txt", "file2.txt"), TCConfig("table", result_TC.toString, "", null, "", "", "", "mountRoot"))
+    val scountAM = TestUtils.scoutAM(List("file1.txt", "file2.txt"), TCConfig("table", result_TC.toString, "", null, "", "", "", "mountRoot", 50))
     val tcResult = Confirmer.tcConfirmer(scountAM).getResult(ccPayload)
 
     tcResult.isError should be(true)
@@ -93,7 +93,7 @@ class ConfirmerTest extends AnyFlatSpec {
   "TC Confirmer getResult" should "return failure when volumes cannot be found" in {
     val filePaths = List("file1.txt", "file2.txt")
     val tcPayload = TCPayload(filePaths)
-    val scoutAM = TestUtils.scoutAM(filePaths, TCConfig("table", result_TC.toString, "", null, "", "", "", "mountRoot"), ScoutAmErrors(true))
+    val scoutAM = TestUtils.scoutAM(filePaths, TCConfig("table", result_TC.toString, "", null, "", "", "", "mountRoot", 50), ScoutAmErrors(true))
     val tcResult = Confirmer.tcConfirmer(scoutAM).getResult(tcPayload)
 
     tcResult.isError should be(true)

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/ModelsTest.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/ModelsTest.scala
@@ -181,7 +181,8 @@ class ModelsTest extends org.scalatest.flatspec.AnyFlatSpec {
         |   "proxy-url": "http://localhost:1234",
         |   "sqs-url": "some_sqs_queue_url",
         |   "dynamo-table-name": "DYNAMO_TABLE",
-        |   "dynamo-attribute-name": "result_CC"
+        |   "dynamo-attribute-name": "result_CC",
+        |   "max-messages": "50"
         |}
         |""".stripMargin
 
@@ -206,7 +207,8 @@ class ModelsTest extends org.scalatest.flatspec.AnyFlatSpec {
         |   "scoutam-base-url":"http://scoutam-base:8080",
         |   "scoutam-username": "Scotty",
         |   "scoutam-password": "Beam Me",
-        |   "mount-root": "/mnt"
+        |   "mount-root": "/mnt",
+        |   "max-messages": "50"
         |}
         |""".stripMargin
 

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/OcflTest.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/OcflTest.scala
@@ -22,7 +22,7 @@ class OcflTest extends AnyFlatSpec:
     repository.putObject(ObjectVersionId.head(existingRef.toString), filePath, new VersionInfo())
     val refHex = DigestUtil.computeDigestHex(DigestAlgorithm.fromOcflName("sha256"), existingRef.toString)
     val path = s"${refHex.slice(0, 3)}/${refHex.slice(3, 6)}/${refHex.slice(6, 9)}/$refHex/v1/content"
-    val ocfl = Ocfl(CCConfig("table", "attribute", "", Some(URI.create("http://localhost")), repoDir, workDir))
+    val ocfl = Ocfl(CCConfig("table", "attribute", "", Some(URI.create("http://localhost")), repoDir, workDir, 50))
     ocfl.getFilePathsForObject(existingRef) should be(List(s"$path/${filePath.getFileName}"))
     ocfl.getFilePathsForObject(nonExistingRef) should be(Nil)
   }

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/OcflTest.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/OcflTest.scala
@@ -41,6 +41,6 @@ class OcflTest extends AnyFlatSpec:
         updater.addPath(filePath)
       }
     )
-    val ocfl = Ocfl(CCConfig("table", "attribute", "", Some(URI.create("http://localhost")), repoDir, workDir))
+    val ocfl = Ocfl(CCConfig("table", "attribute", "", Some(URI.create("http://localhost")), repoDir, workDir, 50))
     ocfl.getFilePathsForObject(existingRef) should be(Nil)
   }

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/ScoutAMTest.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/ScoutAMTest.scala
@@ -8,7 +8,7 @@ import java.net.http.{HttpRequest, HttpResponse}
 class ScoutAMTest extends org.scalatest.flatspec.AnyFlatSpec {
   "ScoutAM" should "return a valid instance of ScoutAM based on the config" in {
     val scoutAM = ScoutAM(
-      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot"),
+      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot", 50),
       new TestHttpService()
     )
     scoutAM shouldBe a[ScoutAM]
@@ -27,7 +27,7 @@ class ScoutAMTest extends org.scalatest.flatspec.AnyFlatSpec {
         |   "checksum": "someChecksumValue"
         |}""".stripMargin
     val scoutAM = ScoutAM(
-      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot"),
+      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot", 50),
       new TestHttpService("", responseForFileDetails, 200, 200)
     )
     val details = scoutAM.getFileDetails(List("/tmp/file1", "/tmp/file2"))
@@ -47,7 +47,7 @@ class ScoutAMTest extends org.scalatest.flatspec.AnyFlatSpec {
         |   "checksum": "someChecksumValue"
         |}""".stripMargin
     val scoutAM = ScoutAM(
-      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot"),
+      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot", 50),
       new TestHttpService("", responseForFileDetails, 200, 200)
     )
     val details = scoutAM.getFileDetails(List("/tmp/file1", "/tmp/file2"))
@@ -56,7 +56,7 @@ class ScoutAMTest extends org.scalatest.flatspec.AnyFlatSpec {
 
   "Authenticate" should "error when authentication is unsuccessful" in {
     val scoutAM = ScoutAM(
-      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot"),
+      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot", 50),
       new TestHttpService("", """{"status": "does-not-matter"}""", 401, 200)
     )
     val ex = intercept[Exception] {
@@ -67,7 +67,7 @@ class ScoutAMTest extends org.scalatest.flatspec.AnyFlatSpec {
 
   "Authenticate" should "error when authentication response cannot be parsed" in {
     val scoutAM = ScoutAM(
-      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot"),
+      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot", 50),
       new TestHttpService("""{"this": "cannot-be-parsed"}""", "", 200, 200)
     )
     val ex = intercept[Exception] {
@@ -78,7 +78,7 @@ class ScoutAMTest extends org.scalatest.flatspec.AnyFlatSpec {
 
   "Get file details" should "return an empty map when unable to retrieve file details" in {
     val scoutAM = ScoutAM(
-      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot"),
+      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot", 50),
       new TestHttpService("", """{"error":"Unauthorized"}""", 200, 401)
     )
     val details = scoutAM.getFileDetails(List("/tmp/file1", "/tmp/file2"))
@@ -87,7 +87,7 @@ class ScoutAMTest extends org.scalatest.flatspec.AnyFlatSpec {
 
   "Get file details" should "return an empty map when the mount root is incorrect" in {
     val scoutAM = ScoutAM(
-      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "incorrectMountRoot"),
+      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "incorrectMountRoot", 50),
       new TestHttpService("", """{"error":"Unauthorized"}""", 200, 401)
     )
     val details = scoutAM.getFileDetails(List("/tmp/file1", "/tmp/file2"))
@@ -106,7 +106,7 @@ class ScoutAMTest extends org.scalatest.flatspec.AnyFlatSpec {
         |  "checksum": null
         |}""".stripMargin
     val scoutAM = ScoutAM(
-      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot"),
+      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot", 50),
       new TestHttpService("", responseForFileDetails, 200, 200)
     )
     val details = scoutAM.getFileDetails(List("/tmp/file1", "/tmp/file2"))
@@ -126,7 +126,7 @@ class ScoutAMTest extends org.scalatest.flatspec.AnyFlatSpec {
         |  "checksum": null
         |}""".stripMargin
     val scoutAM = ScoutAM(
-      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot"),
+      TCConfig("table", result_TC.toString, "", null, "http://scout.base.url:8080", "scout.username", "scout.password", "mountRoot", 50),
       new TestHttpService("", responseForFileDetails, 200, 200)
     )
     val details = scoutAM.getFileDetails(List("/tmp/file1", "/tmp/file2"))

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/TestUtils.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/TestUtils.scala
@@ -52,11 +52,11 @@ object TestUtils:
     repoDir = Files.createTempDirectory("repo")
     (config, confirmer) =
       if dynamoAttributeName == "result_CC" then
-        val ccConfig = CCConfig("table", dynamoAttributeName, "", Some(URI.create("https://example.com")), repoDir.toString, workDir.toString)
+        val ccConfig = CCConfig("table", dynamoAttributeName, "", Some(URI.create("https://example.com")), repoDir.toString, workDir.toString, 50)
         ccConfig -> Confirmer.ccConfirmer(ocfl(existingRefs, ccConfig))
       else
         val tcConfig =
-          TCConfig("table", dynamoAttributeName, "", Some(URI.create("https://example.com")), "https://example.com", "user", "password", "mountRoot")
+          TCConfig("table", dynamoAttributeName, "", Some(URI.create("https://example.com")), "https://example.com", "user", "password", "mountRoot", 50)
         tcConfig -> Confirmer.tcConfirmer(scoutAM(existingPaths, tcConfig))
     _ <- Main
       .runConfirmer(

--- a/utils/src/main/scala/uk/gov/nationalarchives/utils/Utils.scala
+++ b/utils/src/main/scala/uk/gov/nationalarchives/utils/Utils.scala
@@ -120,13 +120,13 @@ object Utils:
       .build()
   }
 
-  def aggregateMessages[F[_]: Sync, T: Decoder](sqs: DASQSClient[F], sqsQueueUrl: String): F[List[MessageResponse[T]]] = {
+  def aggregateMessages[F[_]: Sync, T: Decoder](sqs: DASQSClient[F], sqsQueueUrl: String, maxMessages: Int): F[List[MessageResponse[T]]] = {
     def collectMessages(messages: List[MessageResponse[T]]): F[List[MessageResponse[T]]] = {
       sqs
         .receiveMessages[T](sqsQueueUrl)
         .flatMap { newMessages =>
           val allMessages = newMessages ++ messages
-          if newMessages.isEmpty || allMessages.size >= 50 then Sync[F].pure(allMessages) else collectMessages(allMessages)
+          if newMessages.isEmpty || allMessages.size >= maxMessages then Sync[F].pure(allMessages) else collectMessages(allMessages)
         }
         .handleErrorWith { err =>
           logError(err) >> Sync[F].pure[List[MessageResponse[T]]](messages)


### PR DESCRIPTION
The OCFL library won’t allow (with good reason) concurrent writes to the same OCFL object.

To get around this where multiple assets are written in parallel, we have a semaphore but this had only one permit so only one object could be written at a time. This is making CC quite slow.

The solution is to have a semaphore with one permit per asset in a map.

We do only parallel process at the asset level, that is, two assets will run simultaneously but multiple files within an asset won’t so it’s possible that we don’t even need the semaphore but this is not the time to test that out.

I've also made the number of messages we pick up configurable so we can tweak that without a code deploy.
