### PR TITLE
DR2-2949 Return empty list if there are staged changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,8 +346,10 @@ In case of the CCConfirmer, the payload contains Preservation System ID, so the 
    "payload": "{\"preservationSystemId\": \"d48de631-6fb2-480b-989b-c3b8f48659ec\"}"
 }
 ```
-Based on this ID, the CCConfirmer looks into the OCFL
-repository, if the files are found in the OCFL repository, CCConfirmer, gets the File Paths for all the files. It then updates
+Based on this ID, the CCConfirmer looks into the OCFL repository. 
+If the object does not yet exist, an empty file list is returned. 
+If the object has been created but has staged changes, this means that the backend process is still running for an asset so an empty file list is returned.
+Otherwise, CCConfirmer, gets the File Paths for all the files. It then updates
 the POSTINGEST_STATE_TABLE and saves this list of File Paths into an attribute identified by the `DYNAMO_ATTRIBUTE_NAME`, in case
 of CCConfirmer, this attribute is called `result_CC`. Once this is done, the job of CCConfirmer for this particular Preservation 
 System ID is over.

--- a/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Ocfl.scala
+++ b/custodial-copy-confirmer/src/main/scala/uk/gov/nationalarchives/confirmer/Ocfl.scala
@@ -1,13 +1,13 @@
 package uk.gov.nationalarchives.confirmer
 
-import io.ocfl.api.OcflRepository
+import io.ocfl.api.MutableOcflRepository
 import uk.gov.nationalarchives.utils.Utils.createOcflRepository
 
 import java.util.UUID
 import scala.jdk.CollectionConverters.*
 
 trait Ocfl(val config: CCConfig):
-  private[confirmer] lazy val repo: OcflRepository = createOcflRepository(config.ocflRepoDir, config.ocflWorkDir)
+  private[confirmer] lazy val repo: MutableOcflRepository = createOcflRepository(config.ocflRepoDir, config.ocflWorkDir)
 
   def getFilePathsForObject(id: UUID): List[String]
 
@@ -15,5 +15,6 @@ object Ocfl:
 
   def apply(config: CCConfig): Ocfl = new Ocfl(config):
     override def getFilePathsForObject(id: UUID): List[String] =
-      if repo.containsObject(id.toString) then repo.describeObject(id.toString).getHeadVersion.getFiles.asScala.map(_.getStorageRelativePath).toList
+      if repo.containsObject(id.toString) && !repo.hasStagedChanges(id.toString) then
+        repo.describeObject(id.toString).getHeadVersion.getFiles.asScala.map(_.getStorageRelativePath).toList
       else List.empty

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/OcflTest.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/OcflTest.scala
@@ -1,5 +1,6 @@
 package uk.gov.nationalarchives.confirmer
 
+import io.ocfl.api.MutableOcflRepository
 import io.ocfl.api.model.{DigestAlgorithm, ObjectVersionId, VersionInfo}
 import io.ocfl.core.util.DigestUtil
 import org.scalatest.flatspec.AnyFlatSpec
@@ -25,4 +26,21 @@ class OcflTest extends AnyFlatSpec:
     val ocfl = Ocfl(CCConfig("table", "attribute", "", Some(URI.create("http://localhost")), repoDir, workDir))
     ocfl.getFilePathsForObject(existingRef) should be(List(s"$path/${filePath.getFileName}"))
     ocfl.getFilePathsForObject(nonExistingRef) should be(Nil)
+  }
+
+  "getFilePathsforObject" should "return an empty list if there are staged changes" in {
+    val repoDir = Files.createTempDirectory("repo").toString
+    val workDir = Files.createTempDirectory("work").toString
+    val repository: MutableOcflRepository = createOcflRepository(repoDir, workDir)
+    val existingRef = UUID.randomUUID
+    val filePath = Files.createTempFile(existingRef.toString, "")
+    repository.stageChanges(
+      ObjectVersionId.head(existingRef.toString),
+      new VersionInfo(),
+      updater => {
+        updater.addPath(filePath)
+      }
+    )
+    val ocfl = Ocfl(CCConfig("table", "attribute", "", Some(URI.create("http://localhost")), repoDir, workDir))
+    ocfl.getFilePathsForObject(existingRef) should be(Nil)
   }

--- a/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/OcflTest.scala
+++ b/custodial-copy-confirmer/src/test/scala/uk/gov/nationalarchives/confirmer/OcflTest.scala
@@ -13,7 +13,7 @@ import java.util.UUID
 
 class OcflTest extends AnyFlatSpec:
 
-  "getFilePathsforObject" should "return valid paths if an object exists or empty list otherwise" in {
+  "getFilePathsforObject" should "return valid paths if an object exists and there are no staged changes or empty list otherwise" in {
     val repoDir = Files.createTempDirectory("repo").toString
     val workDir = Files.createTempDirectory("work").toString
     val repository = createOcflRepository(repoDir, workDir)
@@ -28,7 +28,7 @@ class OcflTest extends AnyFlatSpec:
     ocfl.getFilePathsForObject(nonExistingRef) should be(Nil)
   }
 
-  "getFilePathsforObject" should "return an empty list if there are staged changes" in {
+  "getFilePathsforObject" should "return an empty list if an object exists but there are staged changes" in {
     val repoDir = Files.createTempDirectory("repo").toString
     val workDir = Files.createTempDirectory("work").toString
     val repository: MutableOcflRepository = createOcflRepository(repoDir, workDir)

--- a/utils/src/main/scala/uk/gov/nationalarchives/utils/Utils.scala
+++ b/utils/src/main/scala/uk/gov/nationalarchives/utils/Utils.scala
@@ -5,7 +5,7 @@ import cats.syntax.all.*
 import doobie.util.{Get, Put}
 import io.circe.Decoder
 import io.ocfl.api.model.{DigestAlgorithm, ObjectVersionId, OcflObjectVersionFile}
-import io.ocfl.api.{OcflConfig, OcflRepository}
+import io.ocfl.api.{MutableOcflRepository, OcflConfig, OcflRepository}
 import io.ocfl.core.OcflRepositoryBuilder
 import io.ocfl.core.extension.storage.layout.config.HashedNTupleLayoutConfig
 import io.ocfl.core.storage.{OcflStorage, OcflStorageBuilder}
@@ -18,6 +18,7 @@ import java.nio.file.{Files, Paths}
 import java.time.Instant
 import java.util.UUID
 import scala.jdk.CollectionConverters.*
+import scala.jdk.FunctionConverters.*
 import scala.xml.XML
 object Utils:
 
@@ -105,7 +106,7 @@ object Utils:
     }
   }
 
-  def createOcflRepository(ocflRepoDir: String, ocflWorkDir: String): OcflRepository = {
+  def createOcflRepository(ocflRepoDir: String, ocflWorkDir: String): MutableOcflRepository = {
     val repoDir = Paths.get(ocflRepoDir)
     val workDir = Paths.get(ocflWorkDir)
     val storage: OcflStorage = OcflStorageBuilder.builder().fileSystem(repoDir).build
@@ -113,11 +114,17 @@ object Utils:
     ocflConfig.setDefaultDigestAlgorithm(DigestAlgorithm.fromOcflName("sha256"))
     new OcflRepositoryBuilder()
       .defaultLayoutConfig(new HashedNTupleLayoutConfig())
-      .storage(storage)
-      .ocflConfig(ocflConfig)
+      .storage(((osb: OcflStorageBuilder) => {
+        osb.fileSystem(repoDir)
+        ()
+      }).asJava)
+      .ocflConfig(((config: OcflConfig) => {
+        config.setDefaultDigestAlgorithm(DigestAlgorithm.fromOcflName("sha256"))
+        ()
+      }).asJava)
       .prettyPrintJson()
       .workDir(workDir)
-      .build()
+      .buildMutable()
   }
 
   def aggregateMessages[F[_]: Sync, T: Decoder](sqs: DASQSClient[F], sqsQueueUrl: String): F[List[MessageResponse[T]]] = {


### PR DESCRIPTION
The confirmer has been running while the main CC process has been creating the object.

This means that the paths we pass to the tape confirmer are missing some of the files
and are also paths to the extensions directory within the object. These files are moved
when the object is committed so the tape confirmer never finds them.

This checks to see if there are staged changes. If there are, it returns an empty list and the
confirmer will try again on the next run.
