### PR TITLE
Stop overriding the config from the environment variables

### DIFF
--- a/custodial-copy-backend/src/main/resources/application.conf
+++ b/custodial-copy-backend/src/main/resources/application.conf
@@ -10,5 +10,5 @@ queue-timeout=${?QUEUE_TIMEOUT}
 queue-timeout=1h
 potential-ic-db-path=${?IC_DATABASE_PATH}
 files-cache-dir=${FILES_CACHE_DIR}
-max-messages=${?MAX_MESSAGES}
 max-messages=100
+max-messages=${?MAX_MESSAGES}

--- a/custodial-copy-confirmer/src/main/resources/application.conf
+++ b/custodial-copy-confirmer/src/main/resources/application.conf
@@ -8,5 +8,5 @@ scoutam-base-url=${?SCOUTAM_URL}
 scoutam-username=${?SCOUTAM_USERNAME}
 scoutam-password=${?SCOUTAM_PASSWORD}
 mount-root=${?MOUNT_ROOT}
-max-messages=${?MAX_MESSAGES}
 max-messages=50
+max-messages=${?MAX_MESSAGES}


### PR DESCRIPTION
The default value should be first otherwise it just overrides whatever
you put in the environment variable
